### PR TITLE
Plug 66 Feat - blog 002: 게시글 상세 페이지 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-	implementation 'org.json:json:20211205'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.json:json:20211205'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -18,7 +18,7 @@ public class HashtagService {
 
     public Long getHashtagIdByName(String hashtagName) {
         Hashtag hashtag = Optional.ofNullable(hashtagRepository.findByName(hashtagName))
-                .orElseThrow(() -> new ApiException(ErrorStatus._INTERNAL_SERVER_ERROR));
+                .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
 
         return hashtag.getId();
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -5,9 +5,11 @@ import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
+import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONException;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -25,7 +27,7 @@ public class PostController {
     private final CategoryService categoryService;
     private final PhotoService photoService;
 
-    // BLOG001: 블로그 리스트 조회
+    // BLOG001: 블로그 리스트 조회 요청
     /* TODO: 서비스 함수 추가 및 return 해주기 */
     @GetMapping()
     public List<PostRequestDto> ViewList(){
@@ -33,11 +35,12 @@ public class PostController {
         return null;
     }
 
-    // BLOG002: 블로그 상세페이지 조회
+    // BLOG002: 블로그 상세페이지 조회 요청
     @GetMapping("{post_id}")
-    public PostRequestDto ViewPage(@PathVariable long post_id){
-        /*service*/
-        return null;
+    public PostResponseDto ViewPage(@PathVariable long post_id) throws JSONException {
+
+        return postService.getPostById(post_id);
+
     }
 
     // BLOG003: 블로그 작성 요청

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -5,11 +5,9 @@ import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
-import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONException;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -37,10 +35,9 @@ public class PostController {
 
     // BLOG002: 블로그 상세페이지 조회
     @GetMapping("{post_id}")
-    public PostResponseDto ViewPage(@PathVariable long post_id) throws JSONException {
-
-        return postService.getPostById(post_id);
-
+    public PostRequestDto ViewPage(@PathVariable long post_id){
+        /*service*/
+        return null;
     }
 
     // BLOG003: 블로그 작성 요청

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -5,9 +5,11 @@ import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
+import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONException;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -35,9 +37,10 @@ public class PostController {
 
     // BLOG002: 블로그 상세페이지 조회
     @GetMapping("{post_id}")
-    public PostRequestDto ViewPage(@PathVariable long post_id){
-        /*service*/
-        return null;
+    public PostResponseDto ViewPage(@PathVariable long post_id) throws JSONException {
+
+        return postService.getPostById(post_id);
+
     }
 
     // BLOG003: 블로그 작성 요청

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -1,7 +1,10 @@
 package com.justdo.plug.post.domain.post.dto;
+import com.justdo.plug.post.domain.post.Post;
 import lombok.*;
+import org.json.JSONArray;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -16,4 +19,25 @@ public class PostResponseDto {
     private LocalDateTime updated_at;
     private Long member_id;
     private Long blog_id;
+
+    // SUB: 게시글 반환 함수
+    public static PostResponseDto createFromPost(Post post) {
+        String JsonContent = post.getContent();
+        JSONArray jsonArray = new JSONArray(JsonContent);
+        List<Object> list = jsonArray.toList();
+        Object[] array = list.toArray();
+
+        return PostResponseDto.builder()
+                .post_id(post.getId())
+                .title(post.getTitle())
+                .content(array)
+                .like_count(post.getLike_count())
+                .temporary_state(post.isTemporary_state())
+                .state(post.isState())
+                .created_at(post.getCreatedAt())
+                .updated_at(post.getUpdatedAt())
+                .member_id(post.getMember_id())
+                .blog_id(post.getBlog_id())
+                .build();
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -4,15 +4,16 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Data
+@Builder
 public class PostResponseDto {
     private Long post_id;
     private String title;
-    private String content;
+    private Object[] content;
     private int like_count;
     private boolean temporary_state;
     private boolean state;
     private LocalDateTime created_at;
     private LocalDateTime updated_at;
-    private long member_id;
-    private long blog_id;
+    private Long member_id;
+    private Long blog_id;
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -4,16 +4,15 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Data
-@Builder
 public class PostResponseDto {
     private Long post_id;
     private String title;
-    private Object[] content;
+    private String content;
     private int like_count;
     private boolean temporary_state;
     private boolean state;
     private LocalDateTime created_at;
     private LocalDateTime updated_at;
-    private Long member_id;
-    private Long blog_id;
+    private long member_id;
+    private long blog_id;
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -2,10 +2,16 @@ package com.justdo.plug.post.domain.post.service;
 
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
+import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.springframework.stereotype.Service;
+
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -13,7 +19,39 @@ import org.springframework.stereotype.Service;
 public class PostService {
     private final PostRepository postRepository;
 
-    // 블로그 작성
+
+    // BLOG002: 블로그 상세 페이지 조회
+    public PostResponseDto getPostById(long post_id) throws JSONException {
+        Post post = postRepository.findById(post_id)
+                .orElseThrow(() -> new RuntimeException("해당 id의 게시글을 찾을 수 없습니다: " + post_id));
+
+
+        String JsonContent = post.getContent();
+
+        JSONArray jsonArray = new JSONArray(JsonContent);
+
+        List<Object> list = jsonArray.toList();
+
+
+        Object[] array = list.toArray();
+
+        PostResponseDto responseDto =  PostResponseDto.builder()
+                .post_id(post.getId())
+                .title(post.getTitle())
+                .content(array)
+                .temporary_state(post.isTemporary_state())
+                .state(post.isState())
+                .created_at(post.getCreatedAt())
+                .updated_at(post.getUpdatedAt())
+                .member_id(post.getMember_id())
+                .blog_id(post.getBlog_id())
+                .build();
+
+        return responseDto;
+    }
+
+
+    // BLOG003: 블로그 작성
     public Post save(PostRequestDto requestDto) {
        
             Post post = requestDto.toEntity();

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -4,6 +4,8 @@ import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
 import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
+import com.justdo.plug.post.global.exception.ApiException;
+import com.justdo.plug.post.global.response.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONArray;
@@ -21,7 +23,8 @@ public class PostService {
     // BLOG002: 블로그 상세 페이지 조회
     public PostResponseDto getPostById(long post_id) throws JSONException {
         Post post = postRepository.findById(post_id)
-                .orElseThrow(() -> new RuntimeException("해당 id의 게시글을 찾을 수 없습니다: " + post_id));
+                .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
+
 
         return createPostResponseDto(post);
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -8,11 +8,9 @@ import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 
 @Service
 @Transactional
@@ -26,7 +24,7 @@ public class PostService {
                 .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
 
 
-        return createPostResponseDto(post);
+        return PostResponseDto.createFromPost(post);
     }
 
     // BLOG003: 블로그 작성
@@ -35,26 +33,5 @@ public class PostService {
             Post post = requestDto.toEntity();
             return postRepository.save(post);
     }
-
-    // SUB: 게시글 반환 함수
-    private PostResponseDto createPostResponseDto(Post post) throws JSONException {
-        String JsonContent = post.getContent();
-        JSONArray jsonArray = new JSONArray(JsonContent);
-        List<Object> list = jsonArray.toList();
-        Object[] array = list.toArray();
-
-        return PostResponseDto.builder()
-                .post_id(post.getId())
-                .title(post.getTitle())
-                .content(array)
-                .temporary_state(post.isTemporary_state())
-                .state(post.isState())
-                .created_at(post.getCreatedAt())
-                .updated_at(post.getUpdatedAt())
-                .member_id(post.getMember_id())
-                .blog_id(post.getBlog_id())
-                .build();
-    }
-
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -2,10 +2,15 @@ package com.justdo.plug.post.domain.post.service;
 
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
+import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -13,7 +18,34 @@ import org.springframework.stereotype.Service;
 public class PostService {
     private final PostRepository postRepository;
 
-    // 블로그 작성
+    // BLOG002: 블로그 상세 페이지 조회
+    public PostResponseDto getPostById(long post_id) throws JSONException {
+        Post post = postRepository.findById(post_id)
+                .orElseThrow(() -> new RuntimeException("해당 id의 게시글을 찾을 수 없습니다: " + post_id));
+
+        String JsonContent = post.getContent();
+
+        // JSON 파싱
+        JSONArray jsonArray = new JSONArray(JsonContent);
+        List<Object> list = jsonArray.toList();
+        Object[] array = list.toArray();
+
+        PostResponseDto responseDto =  PostResponseDto.builder()
+                .post_id(post.getId())
+                .title(post.getTitle())
+                .content(array)
+                .temporary_state(post.isTemporary_state())
+                .state(post.isState())
+                .created_at(post.getCreatedAt())
+                .updated_at(post.getUpdatedAt())
+                .member_id(post.getMember_id())
+                .blog_id(post.getBlog_id())
+                .build();
+
+        return responseDto;
+    }
+
+    // BLOG003: 블로그 작성
     public Post save(PostRequestDto requestDto) {
        
             Post post = requestDto.toEntity();

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -2,16 +2,10 @@ package com.justdo.plug.post.domain.post.service;
 
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
-import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.springframework.stereotype.Service;
-
-
-import java.util.List;
 
 @Service
 @Transactional
@@ -19,39 +13,7 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
 
-
-    // BLOG002: 블로그 상세 페이지 조회
-    public PostResponseDto getPostById(long post_id) throws JSONException {
-        Post post = postRepository.findById(post_id)
-                .orElseThrow(() -> new RuntimeException("해당 id의 게시글을 찾을 수 없습니다: " + post_id));
-
-
-        String JsonContent = post.getContent();
-
-        JSONArray jsonArray = new JSONArray(JsonContent);
-
-        List<Object> list = jsonArray.toList();
-
-
-        Object[] array = list.toArray();
-
-        PostResponseDto responseDto =  PostResponseDto.builder()
-                .post_id(post.getId())
-                .title(post.getTitle())
-                .content(array)
-                .temporary_state(post.isTemporary_state())
-                .state(post.isState())
-                .created_at(post.getCreatedAt())
-                .updated_at(post.getUpdatedAt())
-                .member_id(post.getMember_id())
-                .blog_id(post.getBlog_id())
-                .build();
-
-        return responseDto;
-    }
-
-
-    // BLOG003: 블로그 작성
+    // 블로그 작성
     public Post save(PostRequestDto requestDto) {
        
             Post post = requestDto.toEntity();

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -23,14 +23,24 @@ public class PostService {
         Post post = postRepository.findById(post_id)
                 .orElseThrow(() -> new RuntimeException("해당 id의 게시글을 찾을 수 없습니다: " + post_id));
 
-        String JsonContent = post.getContent();
+        return createPostResponseDto(post);
+    }
 
-        // JSON 파싱
+    // BLOG003: 블로그 작성
+    public Post save(PostRequestDto requestDto) {
+       
+            Post post = requestDto.toEntity();
+            return postRepository.save(post);
+    }
+
+    // SUB: 게시글 반환 함수
+    private PostResponseDto createPostResponseDto(Post post) throws JSONException {
+        String JsonContent = post.getContent();
         JSONArray jsonArray = new JSONArray(JsonContent);
         List<Object> list = jsonArray.toList();
         Object[] array = list.toArray();
 
-        PostResponseDto responseDto =  PostResponseDto.builder()
+        return PostResponseDto.builder()
                 .post_id(post.getId())
                 .title(post.getTitle())
                 .content(array)
@@ -41,15 +51,6 @@ public class PostService {
                 .member_id(post.getMember_id())
                 .blog_id(post.getBlog_id())
                 .build();
-
-        return responseDto;
-    }
-
-    // BLOG003: 블로그 작성
-    public Post save(PostRequestDto requestDto) {
-       
-            Post post = requestDto.toEntity();
-            return postRepository.save(post);
     }
 
 

--- a/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
@@ -10,35 +10,38 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
-    //일반 응답
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "사용하시려는 해시태그는 사용할 수 없습니다"),
+    // 일반 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // ================================================================================================================= //
+    // 게시글 관련 응답
+    _POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시글을 찾을 수 없습니다."),
+
+    // 해시태그
+    _HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "HASHTAG404", "해당 해시태그를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 
-
     @Override
     public ErrorReasonDto getReason() {
         return ErrorReasonDto.builder()
-            .isSuccess(false)
-            .code(code)
-            .message(message)
-            .build();
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
     }
 
     @Override
     public ErrorReasonDto getReasonHttpStatus() {
         return ErrorReasonDto.builder()
-            .httpStatus(httpStatus)
-            .isSuccess(false)
-            .code(code)
-            .message(message)
-            .build();
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 요약

- 게시글 상세 페이지 조회

## 📝 상세 내용

- 게시글 ID를 넘기면, 그에 해당하는 포스트를 보여주는 기능
- **프론트(BLOCK NOTE JS)와 연동되는지 확인완료**
- content 내요은 프론트에서 바로 파싱해서 쓸 수 있게 Json 배열 -> 배열로 반환해서 보냄
[요청/반환]
<img width="934" alt="Screenshot 2024-04-07 at 12 56 38 AM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/1163a80e-ab74-4b66-820f-ded72399b8ab">

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
