### PR TITLE
PLUG-151 : feat - 게시글 리스트 조회

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -28,11 +28,11 @@ public class PostController {
     private final PhotoService photoService;
 
     // BLOG001: 블로그 리스트 조회 요청
-    /* TODO: 서비스 함수 추가 및 return 해주기 */
     @GetMapping()
-    public List<PostRequestDto> ViewList(){
-        /*service*/
-        return null;
+    public List<Post> ViewList(){
+
+        return postService.getAllPosts();
+
     }
 
     // BLOG002: 블로그 상세페이지 조회 요청

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -11,12 +11,21 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+
+    // BLOG001: 블로그 리스트 조회
+    public List<Post> getAllPosts() {
+
+        return postRepository.findAll();
+
+    }
 
     // BLOG002: 블로그 상세 페이지 조회
     public PostResponseDto getPostById(long post_id) throws JSONException {


### PR DESCRIPTION
## 📌 요약

- 게시글 리스트를 조회하는 API 

## 📝 상세 내용

- 특정 파라미터 or body없이 현재 등록된 모든 게시글을 리스트 형식으로 조회 가능
[예시]
<img width="958" alt="Screenshot 2024-04-07 at 8 48 54 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/491328fc-faa4-4395-ab2b-bf8e8a07be71">


## 🗣️ 질문 및 이외 사항

- 현재는 그냥 모든 글을 리스트로 조회 할 수 있도록 했는데, 나중에 특정 블로그만 조회 하는게 필요할것 같은데 API명세서에 없어서 또 따로 추가해서 만들면 좋을까요

## ☑️ 이슈 번호

- close #
