### PR TITLE
PLUG-153 : feat - 특정 블로그 게시글 조회

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/category/Category.java
+++ b/src/main/java/com/justdo/plug/post/domain/category/Category.java
@@ -11,12 +11,12 @@ import lombok.*;
 public class Category extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long category_id;
+    private Long categoryId;
 
     @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)
-    private Long post_id;
+    private Long postId;
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/category/service/CategoryService.java
+++ b/src/main/java/com/justdo/plug/post/domain/category/service/CategoryService.java
@@ -15,9 +15,9 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
 
-    public void createCategory(String name, Long post_id){
+    public void createCategory(String name, Long postId){
 
-        Category category = Category.builder().name(name).post_id(post_id).build();
+        Category category = Category.builder().name(name).postId(postId).build();
         save(category);
     }
     public void save(Category category){

--- a/src/main/java/com/justdo/plug/post/domain/post/Post.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/Post.java
@@ -28,15 +28,15 @@ public class Post extends BaseTimeEntity {
     private int like_count;
 
     @Column(nullable = false)
-    private boolean temporary_state;
+    private boolean temporaryState;
 
     @Column(nullable = false)
     private boolean state;
 
     @Column(nullable = false, updatable = false)
-    private Long blog_id;
+    private Long blogId;
 
     @Column(nullable = false, updatable = false)
-    private Long member_id;
+    private Long memberId;
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -27,7 +27,7 @@ public class PostController {
     private final CategoryService categoryService;
     private final PhotoService photoService;
 
-    // BLOG001: 블로그 리스트 조회 요청
+    // BLOG001: 게시글 리스트 조회 요청
     @GetMapping()
     public List<Post> ViewList(){
 
@@ -35,17 +35,17 @@ public class PostController {
 
     }
 
-    // BLOG002: 블로그 상세페이지 조회 요청
+    // BLOG002: 게시글 상세페이지 조회 요청
     @GetMapping("{post_id}")
-    public PostResponseDto ViewPage(@PathVariable long post_id) throws JSONException {
+    public PostResponseDto ViewPage(@PathVariable Long post_id) throws JSONException {
 
         return postService.getPostById(post_id);
 
     }
 
-    // BLOG003: 블로그 작성 요청
+    // BLOG003: 게시글 작성 요청
     @PostMapping("{blog_id}")
-    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable long blog_id) {
+    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blog_id) {
 
             // 1. Post 저장
             RequestDto.setBlog_id(blog_id);
@@ -69,18 +69,26 @@ public class PostController {
             return "게시글이 성공적으로 업로드 되었습니다";
     }
 
-    // BLOG004: 블로그 수정 요청
+    // BLOG004: 게시글 수정 요청
     @PatchMapping("{post_id}")
-    public PostRequestDto EditBlog(@PathVariable long post_id){
+    public PostRequestDto EditBlog(@PathVariable Long post_id){
         /*service*/
         return null;
     }
 
-    // BLOG005: 블로그 삭제 요청
+    // BLOG005: 게시글 삭제 요청
     @DeleteMapping("{post_id}")
-    public PostRequestDto DeleteBlog(@PathVariable long post_id){
+    public PostRequestDto DeleteBlog(@PathVariable Long post_id){
         /*service*/
         return null;
+    }
+
+    // BLOG006: 블로그 게시글 리스트 조회 요청
+    @GetMapping("blog/{blog_id}")
+    public List<Post> ViewBlogList(@PathVariable Long blog_id){
+
+        return postService.getBlogPosts(blog_id);
+
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -36,58 +36,58 @@ public class PostController {
     }
 
     // BLOG002: 게시글 상세페이지 조회 요청
-    @GetMapping("{post_id}")
-    public PostResponseDto ViewPage(@PathVariable Long post_id) throws JSONException {
+    @GetMapping("{postId}")
+    public PostResponseDto ViewPage(@PathVariable Long postId) throws JSONException {
 
-        return postService.getPostById(post_id);
+        return postService.getPostById(postId);
 
     }
 
     // BLOG003: 게시글 작성 요청
-    @PostMapping("{blog_id}")
-    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blog_id) {
+    @PostMapping("{blogId}")
+    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blogId) {
 
             // 1. Post 저장
-            RequestDto.setBlog_id(blog_id);
+            RequestDto.setBlogId(blogId);
             Post post = postService.save(RequestDto);
 
             // Post 에서 post_id 받아오기
-            Long post_id = post.getId();
+            Long postId = post.getId();
 
             // 2. Post_Hashtag 저장
             List<String> hashtags = RequestDto.getHashtags();
-            postHashtagService.createHashtag(hashtags, post_id);
+            postHashtagService.createHashtag(hashtags, postId);
 
             // 3. Category 저장
             String name = RequestDto.getName(); // '카테고리 명'저장
-            categoryService.createCategory(name, post_id);
+            categoryService.createCategory(name, postId);
 
             // 4. Photo 저장
             String photo_url = RequestDto.getPhoto_url();
-            photoService.createPhoto(photo_url, post_id);
+            photoService.createPhoto(photo_url, postId);
 
             return "게시글이 성공적으로 업로드 되었습니다";
     }
 
     // BLOG004: 게시글 수정 요청
-    @PatchMapping("{post_id}")
-    public PostRequestDto EditBlog(@PathVariable Long post_id){
+    @PatchMapping("{postId}")
+    public PostRequestDto EditBlog(@PathVariable Long postId){
         /*service*/
         return null;
     }
 
     // BLOG005: 게시글 삭제 요청
-    @DeleteMapping("{post_id}")
-    public PostRequestDto DeleteBlog(@PathVariable Long post_id){
+    @DeleteMapping("{postId}")
+    public PostRequestDto DeleteBlog(@PathVariable Long postId){
         /*service*/
         return null;
     }
 
     // BLOG006: 블로그 게시글 리스트 조회 요청
-    @GetMapping("blog/{blog_id}")
-    public List<Post> ViewBlogList(@PathVariable Long blog_id){
+    @GetMapping("blog/{blogId}")
+    public List<Post> ViewBlogList(@PathVariable Long blogId){
 
-        return postService.getBlogPosts(blog_id);
+        return postService.getBlogPosts(blogId);
 
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
@@ -11,10 +11,10 @@ public class PostRequestDto {
     private String title;
     private String content;
     private int like_count;
-    private boolean temporary_state;
+    private boolean temporaryState;
     private boolean state;
-    private long member_id;
-    private long blog_id;
+    private long memberId;
+    private long blogId;
     private List<String> hashtags;
     private String name;
     private String photo_url;
@@ -24,10 +24,10 @@ public class PostRequestDto {
         return Post.builder()
                 .title(title)
                 .content(content)
-                .temporary_state(temporary_state)
+                .temporaryState(temporaryState)
                 .state(state)
-                .member_id(member_id)
-                .blog_id(blog_id)
+                .memberId(memberId)
+                .blogId(blogId)
                 .build();
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -9,16 +9,16 @@ import java.util.List;
 @Data
 @Builder
 public class PostResponseDto {
-    private Long post_id;
+    private Long postId;
     private String title;
     private Object[] content;
     private int like_count;
-    private boolean temporary_state;
+    private boolean temporaryState;
     private boolean state;
     private LocalDateTime created_at;
     private LocalDateTime updated_at;
-    private Long member_id;
-    private Long blog_id;
+    private Long memberId;
+    private Long blogId;
 
     // SUB: 게시글 반환 함수
     public static PostResponseDto createFromPost(Post post) {
@@ -28,16 +28,16 @@ public class PostResponseDto {
         Object[] array = list.toArray();
 
         return PostResponseDto.builder()
-                .post_id(post.getId())
+                .postId(post.getId())
                 .title(post.getTitle())
                 .content(array)
                 .like_count(post.getLike_count())
-                .temporary_state(post.isTemporary_state())
+                .temporaryState(post.isTemporaryState())
                 .state(post.isState())
                 .created_at(post.getCreatedAt())
                 .updated_at(post.getUpdatedAt())
-                .member_id(post.getMember_id())
-                .blog_id(post.getBlog_id())
+                .memberId(post.getMemberId())
+                .blogId(post.getBlogId())
                 .build();
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    @Query("SELECT p FROM Post p WHERE p.blog_id = :blog_id")
+
     List<Post> findByBlogId(Long blog_id);
 
 

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -2,9 +2,15 @@ package com.justdo.plug.post.domain.post.repository;
 
 import com.justdo.plug.post.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query("SELECT p FROM Post p WHERE p.blog_id = :blog_id")
+    List<Post> findByBlogId(Long blog_id);
+
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -20,18 +20,17 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
 
-    // BLOG001: 블로그 리스트 조회
+    // BLOG001: 게시글 리스트 조회
     public List<Post> getAllPosts() {
 
         return postRepository.findAll();
 
     }
 
-    // BLOG002: 블로그 상세 페이지 조회
-    public PostResponseDto getPostById(long post_id) throws JSONException {
+    // BLOG002: 게시글 상세 페이지 조회
+    public PostResponseDto getPostById(Long post_id) throws JSONException {
         Post post = postRepository.findById(post_id)
                 .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
-
 
         return PostResponseDto.createFromPost(post);
     }
@@ -41,6 +40,15 @@ public class PostService {
        
             Post post = requestDto.toEntity();
             return postRepository.save(post);
+    }
+
+    // BLOG006: 블로그 게시글 리스트 조회
+    public List<Post> getBlogPosts(Long blog_id){
+        List<Post> posts = postRepository.findByBlogId(blog_id);
+        if(posts.isEmpty()) {
+            throw new ApiException(ErrorStatus._POST_NOT_FOUND);
+        }
+        return posts;
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
     public List<Post> getBlogPosts(Long blog_id){
         List<Post> posts = postRepository.findByBlogId(blog_id);
         if(posts.isEmpty()) {
-            throw new ApiException(ErrorStatus._POST_NOT_FOUND);
+            throw new ApiException(ErrorStatus._BLOG_NOT_FOUND);
         }
         return posts;
     }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/PostHashtag.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/PostHashtag.java
@@ -15,19 +15,12 @@ import lombok.Setter;
 public class PostHashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long post_hashtag_id;
+    private Long postHashtagId;
 
     @Column(nullable = false)
-    private Long post_id;
+    private Long postId;
 
     @Column(nullable = false)
-    private Long hashtag_id;
+    private Long hashtagId;
 
-    public void setPostId(Long post_id) {
-        this.post_id = post_id;
-    }
-
-    public void setHashtagId(Long hashtag_id) {
-        this.hashtag_id = hashtag_id;
-    }
 }

--- a/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
@@ -19,6 +19,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 게시글 관련 응답
     _POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시글을 찾을 수 없습니다."),
 
+    //블로그
+    _BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOG404", "해당 블로그를 찾을 수 없습니다."),
+
     // 해시태그
     _HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "HASHTAG404", "해당 해시태그를 찾을 수 없습니다.");
 


### PR DESCRIPTION
## 📌 요약

- 특정 블로그 게시글 조회

## 📝 상세 내용

- 엔드포인트: /posts/blog/{blog_id}

<img width="954" alt="Screenshot 2024-04-08 at 5 11 06 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/036ecf29-6b02-4b08-a8df-3de95b24bbde">

- 블로그 아이디 기준(특정인의 블로그) 그 블로그에 올라온 글만 조회

## 🗣️ 질문 및 이외 사항

- 현재 findByBlogId가 자꾸 Post의 blog_id를 인식을 못하고 blogId만 인식을 했습니다. (구글링 아무리 해보고 chatGPT에 찾아봐도 이유가 뭔지 모르겟음 낙타표기법으로 findByBlogId로 해도 blog_id가 조회가 된다는데 왜 못하는지 모르겠슴)
- **때문에 일단 직접 함수에 쿼리문을 담아서 실행시키는걸로 진행을 했는데 (정상작동)** , 이렇게 진행해도 되는지 의견을 듣고자 합니다.

- 추가로 이번 [게시글 작성 조회 수정 삭제 ] api 전부 머지한뒤, api 명세서 정리해서 노션에 올려서 프론트와 애기해볼 예정입니다.

## ☑️ 이슈 번호

- close #
