### PR TITLE
Glue - 242   feat hashtag값 추출 api

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 @AllArgsConstructor
 public class Hashtag extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/repository/HashtagRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     Hashtag findByName(String hashtagName);
 
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -31,4 +31,10 @@ public class HashtagService {
 
         return hashtagRepository.save(newHashtag);
     }
+
+    public String getHashtagNameById(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.findById(hashtagId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
+        return hashtag.getName();
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -8,8 +8,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -18,10 +16,8 @@ public class HashtagService {
 
     public Long getHashtagIdByName(String hashtagName) {
         Hashtag hashtag = hashtagRepository.findByName(hashtagName);
-        if (hashtag == null) {
-            // 만약 해당하는 이름의 해시태그가 없는 경우 새로운 해시태그를 생성
-            hashtag = createNewHashtag(hashtagName);
-        }
+        // 만약 사용하려는 해시태그가 없다면 새로운 해시태그 생성 후 사용
+        hashtag = (hashtag == null) ? createNewHashtag(hashtagName) : hashtag;
         return hashtag.getId();
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -17,9 +17,18 @@ public class HashtagService {
     private final HashtagRepository hashtagRepository;
 
     public Long getHashtagIdByName(String hashtagName) {
-        Hashtag hashtag = Optional.ofNullable(hashtagRepository.findByName(hashtagName))
-                .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
-
+        Hashtag hashtag = hashtagRepository.findByName(hashtagName);
+        if (hashtag == null) {
+            // 만약 해당하는 이름의 해시태그가 없는 경우 새로운 해시태그를 생성
+            hashtag = createNewHashtag(hashtagName);
+        }
         return hashtag.getId();
+    }
+
+    private Hashtag createNewHashtag(String hashtagName) {
+        Hashtag newHashtag = new Hashtag();
+        newHashtag.setName(hashtagName);
+
+        return hashtagRepository.save(newHashtag);
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/photo/Photo.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/Photo.java
@@ -18,7 +18,7 @@ public class Photo extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long photoId;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String photoUrl;
 
     @Column(nullable = false)

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -88,6 +88,13 @@ public class PostController {
     public List<Post> ViewBlogList(@PathVariable Long blogId){
 
         return postService.getBlogPosts(blogId);
+    }
+
+    // BlOG007: 특정 멤버가 사용한 HASHTAG 값 조회
+    @GetMapping("member/{memberId}")
+    public List<Post> ViewHashtags(@PathVariable Long memberId){
+
+        return postService.getHashtags(memberId);
 
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -92,7 +92,7 @@ public class PostController {
 
     // BlOG007: 특정 멤버가 사용한 HASHTAG 값 조회
     @GetMapping("member/{memberId}")
-    public List<Post> ViewHashtags(@PathVariable Long memberId){
+    public List<String> ViewHashtags(@PathVariable Long memberId){
 
         return postService.getHashtags(memberId);
 

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -13,4 +13,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByBlogId(Long blogId);
 
 
+    List<Post> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -51,4 +51,14 @@ public class PostService {
         return posts;
     }
 
+    // BLOG007: 해시태그 값 추출
+    public List<Post> getHashtags(Long memberId){
+        List<Post> memberPosts = postRepository.findByMemberId(memberId);
+        if(memberPosts.isEmpty()) {
+            throw new ApiException(ErrorStatus._NO_HASHTAGS);
+        }
+
+        return memberPosts;
+    }
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/repository/PostHashtagRepository.java
@@ -4,7 +4,9 @@ import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long>{
-
+    List<PostHashtag> findByPostId(Long postId);
 }

--- a/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOG404", "해당 블로그를 찾을 수 없습니다."),
 
     //해시태그
-    _NO_HASHTAGS(HttpStatus.NOT_FOUND, "BLOG404", "해당 사용자가 사용한 해시태그를 찾을 수 없습니다."),
+    _NO_HASHTAGS(HttpStatus.NOT_FOUND, "HASHTAGS404", "해당 사용자가 사용한 해시태그를 찾을 수 없습니다."),
 
     // 해시태그
     _HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "HASHTAG404", "해당 해시태그를 찾을 수 없습니다.");

--- a/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
@@ -22,6 +22,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //블로그
     _BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOG404", "해당 블로그를 찾을 수 없습니다."),
 
+    //해시태그
+    _NO_HASHTAGS(HttpStatus.NOT_FOUND, "BLOG404", "해당 사용자가 사용한 해시태그를 찾을 수 없습니다."),
+
     // 해시태그
     _HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "HASHTAG404", "해당 해시태그를 찾을 수 없습니다.");
 


### PR DESCRIPTION
## 📌 요약

- 사용자 아이디를 입력했을때 사용자가 사용한 해시태그 값을 리스트로 변환해주는 API

## 📝 상세 내용
<img width="953" alt="Screenshot 2024-04-26 at 9 06 26 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/a9be6c2d-f9c2-41a0-8d18-e62753e501fb">

- 사용자 아이디를 넘겨주면
1. 사용자가 작성한 모든 게시글을 확인 
2. 게시글에서 사용된 해시태그 아이디 추출
3. 해시태그 아이디 => 해시태그 명으로 변경
4. 모든 해시태그명 리스트에 저장 및 중복처리

<img width="139" alt="KakaoTalk_Photo_2024-04-26-21-08-04" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/aad2005c-1555-4a6f-b059-7045e9c4bf57">

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
