### PR TITLE
Glue 246   feat 게시글 content에서 text값만 조회

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
@@ -4,10 +4,11 @@ import com.justdo.plug.post.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+@Builder
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Hashtag extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -21,9 +21,10 @@ public class HashtagService {
         return hashtag.getId();
     }
 
-    private Hashtag createNewHashtag(String hashtagName) {
-        Hashtag newHashtag = new Hashtag();
-        newHashtag.setName(hashtagName);
+    public Hashtag createNewHashtag(String hashtagName) {
+        Hashtag newHashtag = Hashtag.builder()
+                .name(hashtagName)
+                .build();
 
         return hashtagRepository.save(newHashtag);
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/Post.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/Post.java
@@ -39,4 +39,7 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false, updatable = false)
     private Long memberId;
 
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String preview;
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.justdo.plug.post.domain.post.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.justdo.plug.post.domain.category.service.CategoryService;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
@@ -95,6 +96,14 @@ public class PostController {
     public List<String> ViewHashtags(@PathVariable Long memberId){
 
         return postService.getHashtags(memberId);
+
+    }
+
+    // BlOG008: 게시글의 글만 조회하기
+    @GetMapping("preview/{postId}")
+    public String PreviewPost(@PathVariable Long postId) throws JsonProcessingException {
+
+        return postService.getPreviewPost(postId);
 
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -46,10 +46,14 @@ public class PostController {
 
     // BLOG003: 게시글 작성 요청
     @PostMapping("{blogId}")
-    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blogId) {
+    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blogId) throws JsonProcessingException {
 
             // 1. Post 저장
             RequestDto.setBlogId(blogId);
+            // 1-2. Preview 저장
+            String content = RequestDto.getContent();
+            String preview = postService.savePreviewPost(content);
+            RequestDto.setPreview(preview);
             Post post = postService.save(RequestDto);
 
             // Post 에서 post_id 받아오기
@@ -66,6 +70,8 @@ public class PostController {
             // 4. Photo 저장
             String photoUrl = RequestDto.getPhotoUrl();
             photoService.createPhoto(photoUrl, postId);
+
+
 
             return "게시글이 성공적으로 업로드 되었습니다";
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
@@ -18,7 +18,7 @@ public class PostRequestDto {
     private List<String> hashtags;
     private String name;
     private String photoUrl;
-
+    private String preview;
 
     public Post toEntity(){
         return Post.builder()
@@ -28,6 +28,7 @@ public class PostRequestDto {
                 .state(state)
                 .memberId(memberId)
                 .blogId(blogId)
+                .preview(preview)
                 .build();
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.justdo.plug.post.domain.post.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
@@ -14,8 +15,11 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 
 @Service
@@ -88,6 +92,32 @@ public class PostService {
 
 
         return hashtagNames;
+    }
+
+    // BlOG008: 게시글의 글만 조회하기
+    public String getPreviewPost(Long postId) throws JsonProcessingException {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
+
+        String preview = post.getContent();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonArray = mapper.readTree(preview);
+
+        StringBuilder extractedTexts = new StringBuilder();
+        for (JsonNode node : jsonArray) {
+            JsonNode contentArray = node.path("content");
+            if (contentArray.isArray()) {
+                for (JsonNode contentObj : contentArray) {
+                    if (contentObj.isObject()) {
+                        String text = contentObj.path("text").asText();
+                        extractedTexts.append(text).append(" ");
+                    }
+                }
+            }
+        }
+
+        return extractedTexts.toString().trim();
     }
 
 

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -7,7 +7,7 @@ import com.justdo.plug.post.domain.post.dto.PostRequestDto;
 import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import com.justdo.plug.post.domain.posthashtag.PostHashtag;
-import com.justdo.plug.post.domain.posthashtag.repository.PostHashtagRepository;
+import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 
 @Service
@@ -27,8 +26,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
-    private final PostHashtagRepository postHashtagRepository;
     private final HashtagService hashtagService;
+    private final PostHashtagService postHashtagService;
 
 
     // BLOG001: 게시글 리스트 조회
@@ -82,7 +81,8 @@ public class PostService {
         // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
         for (Long postId : postIds) {
             List<PostHashtag> postHashtags;
-            postHashtags = postHashtagRepository.findByPostId(postId);
+            postHashtags = postHashtagService.getPostHashtags(postId);
+
             for (PostHashtag postHashtag : postHashtags) {
                 // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
                 String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -120,5 +120,27 @@ public class PostService {
         return extractedTexts.toString().trim();
     }
 
+    // BlOG009: 게시글의 preview 값 저장
+    public String savePreviewPost(String content) throws JsonProcessingException {
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonArray = mapper.readTree(content);
+
+        StringBuilder extractedTexts = new StringBuilder();
+        for (JsonNode node : jsonArray) {
+            JsonNode contentArray = node.path("content");
+            if (contentArray.isArray()) {
+                for (JsonNode contentObj : contentArray) {
+                    if (contentObj.isObject()) {
+                        String text = contentObj.path("text").asText();
+                        extractedTexts.append(text).append(" ");
+                    }
+                }
+            }
+        }
+
+        return extractedTexts.toString().trim();
+    }
+
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -32,6 +32,13 @@ public class PostHashtagService {
         }
 
     }
+
+    public List<PostHashtag> getPostHashtags(Long postId){
+
+        return postHashtagRepository.findByPostId(postId);
+
+    }
+
     public void save(PostHashtag postHashtag) {
         postHashtagRepository.save(postHashtag);
     }


### PR DESCRIPTION
## 📌 요약

- 포스트 아이디에 따라 UI 컴포넌트를 제외한 text값만 보여주는 API입니다

## 📝 상세 내용

- postId 넘겨주면 아래와 같이 글만 보여짐

<img width="957" alt="Screenshot 2024-04-27 at 5 07 22 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/abe6fe0b-59ba-4713-a5e5-65f308bea4fb">

[참고: figma]
아래와 같이 미리 보여지는 게시글은 글만 보여줄수 있도록 하기 위함임

<img width="566" alt="Screenshot 2024-04-27 at 5 08 16 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/32faca41-1ffa-4324-86de-fbba38fbaaa5">

## 🗣️ 질문 및 이외 사항

- 

## ☑️ 이슈 번호

- close #
