### PR TITLE
GLUE-248 : feat - 블로그 아이디로 해시태그 추출

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -34,4 +34,6 @@ public class HashtagService {
                 .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
         return hashtag.getName();
     }
+
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -98,7 +98,7 @@ public class PostController {
     }
 
     // BlOG007: 특정 멤버가 사용한 HASHTAG 값 조회
-    @GetMapping("member/{memberId}")
+    @GetMapping("memberId/{memberId}")
     public List<String> ViewHashtags(@PathVariable Long memberId){
 
         return postService.getHashtags(memberId);
@@ -111,6 +111,12 @@ public class PostController {
 
         return postService.getPreviewPost(postId);
 
+    }
+
+    // BLOG009: 블로그 아이디로 해시태그 추출하기
+    @GetMapping("blogId/{blogId}")
+    public List<String> ViewHashtagsBlog(@PathVariable Long blogId){
+        return postService.getHashtagsBlog(blogId);
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -101,7 +101,7 @@ public class PostController {
     @GetMapping("memberId/{memberId}")
     public List<String> ViewHashtags(@PathVariable Long memberId){
 
-        return postService.getHashtags(memberId);
+        return postHashtagService.getHashtags(memberId);
 
     }
 
@@ -116,7 +116,7 @@ public class PostController {
     // BLOG009: 블로그 아이디로 해시태그 추출하기
     @GetMapping("blogId/{blogId}")
     public List<String> ViewHashtagsBlog(@PathVariable Long blogId){
-        return postService.getHashtagsBlog(blogId);
+        return postHashtagService.getHashtagsBlog(blogId);
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -1,13 +1,12 @@
 package com.justdo.plug.post.domain.post.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.justdo.plug.post.domain.hashtag.service.HashtagService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
 import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
-import com.justdo.plug.post.domain.posthashtag.PostHashtag;
-import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
@@ -15,9 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
 import java.util.List;
 
 
@@ -26,8 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
-    private final HashtagService hashtagService;
-    private final PostHashtagService postHashtagService;
+
 
 
     // BLOG001: 게시글 리스트 조회
@@ -59,39 +54,6 @@ public class PostService {
             throw new ApiException(ErrorStatus._BLOG_NOT_FOUND);
         }
         return posts;
-    }
-
-    // BLOG007: 해시태그 값 추출
-    public List<String> getHashtags(Long memberId) {
-        // 멤버 아이디에 해당하는 포스트를 가져온다.
-        List<Post> memberPosts = postRepository.findByMemberId(memberId);
-
-        // 멤버 아이디에 해당하는 포스트가 없는 경우
-        if (memberPosts.isEmpty()) {
-            throw new ApiException(ErrorStatus._NO_HASHTAGS);
-        }
-
-        // 멤버 아이디에 해당하는 포스트의 아이디만 추출하여 반환
-        List<Long> postIds = memberPosts.stream()
-                .map(Post::getId)
-                .toList();
-
-        List<String> hashtagNames = new ArrayList<>();
-
-        // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
-        for (Long postId : postIds) {
-            List<PostHashtag> postHashtags;
-            postHashtags = postHashtagService.getPostHashtags(postId);
-
-            for (PostHashtag postHashtag : postHashtags) {
-                // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
-                String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());
-                hashtagNames.add(hashtagName);
-            }
-        }
-
-
-        return hashtagNames;
     }
 
     // BlOG008: 게시글의 글만 조회하기
@@ -142,38 +104,6 @@ public class PostService {
         return extractedTexts.toString().trim();
     }
 
-    // BLOG009: 블로그 아이디로 해시태그 추출하기
-    public List<String> getHashtagsBlog(Long blogId){
 
-        // 블로그 아이디에 해당하는 포스트를 가져온다.
-        List<Post> blogPosts = postRepository.findByBlogId(blogId);
-
-        // 블로그 아이디에 해당하는 포스트가 없는 경우
-        if (blogPosts.isEmpty()) {
-            throw new ApiException(ErrorStatus._NO_HASHTAGS);
-        }
-
-        // 블로그 아이디에 해당하는 포스트의 아이디만 추출하여 반환
-        List<Long> postIds = blogPosts.stream()
-                .map(Post::getId)
-                .toList();
-
-        List<String> hashtagNames = new ArrayList<>();
-
-        // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
-        for (Long postId : postIds) {
-            List<PostHashtag> postHashtags;
-            postHashtags = postHashtagService.getPostHashtags(postId);
-
-            for (PostHashtag postHashtag : postHashtags) {
-                // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
-                String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());
-                hashtagNames.add(hashtagName);
-            }
-        }
-
-
-        return hashtagNames;
-    }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -120,7 +120,7 @@ public class PostService {
         return extractedTexts.toString().trim();
     }
 
-    // BlOG009: 게시글의 preview 값 저장
+    // 게시글의 preview 값 저장
     public String savePreviewPost(String content) throws JsonProcessingException {
 
         ObjectMapper mapper = new ObjectMapper();
@@ -142,5 +142,38 @@ public class PostService {
         return extractedTexts.toString().trim();
     }
 
+    // BLOG009: 블로그 아이디로 해시태그 추출하기
+    public List<String> getHashtagsBlog(Long blogId){
+
+        // 블로그 아이디에 해당하는 포스트를 가져온다.
+        List<Post> blogPosts = postRepository.findByBlogId(blogId);
+
+        // 블로그 아이디에 해당하는 포스트가 없는 경우
+        if (blogPosts.isEmpty()) {
+            throw new ApiException(ErrorStatus._NO_HASHTAGS);
+        }
+
+        // 블로그 아이디에 해당하는 포스트의 아이디만 추출하여 반환
+        List<Long> postIds = blogPosts.stream()
+                .map(Post::getId)
+                .toList();
+
+        List<String> hashtagNames = new ArrayList<>();
+
+        // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
+        for (Long postId : postIds) {
+            List<PostHashtag> postHashtags;
+            postHashtags = postHashtagService.getPostHashtags(postId);
+
+            for (PostHashtag postHashtag : postHashtags) {
+                // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
+                String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());
+                hashtagNames.add(hashtagName);
+            }
+        }
+
+
+        return hashtagNames;
+    }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -1,12 +1,17 @@
 package com.justdo.plug.post.domain.posthashtag.service;
 
-import com.justdo.plug.post.domain.hashtag.service.HashtagService;
+import com.justdo.plug.post.domain.post.Post;
+import com.justdo.plug.post.domain.post.repository.PostRepository;
 import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import com.justdo.plug.post.domain.posthashtag.repository.PostHashtagRepository;
+import com.justdo.plug.post.domain.hashtag.service.HashtagService;
+import com.justdo.plug.post.global.exception.ApiException;
+import com.justdo.plug.post.global.response.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,10 +20,10 @@ import java.util.List;
 public class PostHashtagService {
     private final PostHashtagRepository postHashtagRepository;
     private final HashtagService hashtagService;
+    private final PostRepository postRepository;
+
     public void createHashtag(List<String> hashtags, Long postId){
-
         for (String hashtag : hashtags) {
-
             // 해시태그 이름으로 해시태그 ID를 가져오는 메서드
             Long hashtagId = hashtagService.getHashtagIdByName(hashtag);
 
@@ -30,13 +35,77 @@ public class PostHashtagService {
             // Post_Hashtag 엔티티 저장
             save(postHashtag);
         }
+    }
 
+    // BLOG009: 블로그 아이디로 해시태그 추출하기
+    public List<String> getHashtagsBlog(Long blogId){
+
+        // 블로그 아이디에 해당하는 포스트를 가져온다.
+        List<Post> blogPosts = postRepository.findByBlogId(blogId);
+
+        // 블로그 아이디에 해당하는 포스트가 없는 경우
+        if (blogPosts.isEmpty()) {
+            throw new ApiException(ErrorStatus._NO_HASHTAGS);
+        }
+
+        // 블로그 아이디에 해당하는 포스트의 아이디만 추출하여 반환
+        List<Long> postIds = blogPosts.stream()
+                .map(Post::getId)
+                .toList();
+
+        List<String> hashtagNames = new ArrayList<>();
+
+        // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
+        for (Long postId : postIds) {
+            List<PostHashtag> postHashtags;
+            postHashtags = getPostHashtags(postId);
+
+            for (PostHashtag postHashtag : postHashtags) {
+                // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
+                String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());
+                hashtagNames.add(hashtagName);
+            }
+        }
+
+
+        return hashtagNames;
+    }
+
+    // BLOG007: 해시태그 값 추출
+    public List<String> getHashtags(Long memberId) {
+        // 멤버 아이디에 해당하는 포스트를 가져온다.
+        List<Post> memberPosts = postRepository.findByMemberId(memberId);
+
+        // 멤버 아이디에 해당하는 포스트가 없는 경우
+        if (memberPosts.isEmpty()) {
+            throw new ApiException(ErrorStatus._NO_HASHTAGS);
+        }
+
+        // 멤버 아이디에 해당하는 포스트의 아이디만 추출하여 반환
+        List<Long> postIds = memberPosts.stream()
+                .map(Post::getId)
+                .toList();
+
+        List<String> hashtagNames = new ArrayList<>();
+
+        // 각 포스트별로 해당하는 해시태그 아이디를 추출하여 저장
+        for (Long postId : postIds) {
+            List<PostHashtag> postHashtags;
+            postHashtags = getPostHashtags(postId);
+
+            for (PostHashtag postHashtag : postHashtags) {
+                // 아이디에서 해시태그 명으로 변경 후 리스트에 저장
+                String hashtagName = hashtagService.getHashtagNameById(postHashtag.getHashtagId());
+                hashtagNames.add(hashtagName);
+            }
+        }
+
+
+        return hashtagNames;
     }
 
     public List<PostHashtag> getPostHashtags(Long postId){
-
         return postHashtagRepository.findByPostId(postId);
-
     }
 
     public void save(PostHashtag postHashtag) {


### PR DESCRIPTION
## 📌 요약

- 특정 블로그 아이디에 대해 블로그에서 사용한 해시태그 값 전부 가져오는 API

## 📝 상세 내용

- PathVariable로 블로그 아이디를 넘겨주면, 그 블로그에서 사용한 모든 해시태그값들을 리스트로 받아 볼 수 있음.

<img width="944" alt="Screenshot 2024-04-28 at 2 58 05 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/31ae8dba-a459-48fd-b0df-6f555fd0425c">

## 🗣️ 질문 및 이외 사항

- @kylo-dev 요청으로 제작하게 됨

## ☑️ 이슈 번호

- close #
