### PR TITLE
Glue 247 Feat: 개인 블로그에 보이는 최신순 Post 조회 API 구현

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/Hashtag.java
@@ -1,8 +1,17 @@
 package com.justdo.plug.post.domain.hashtag;
 
 import com.justdo.plug.post.domain.common.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Builder
 @Entity
@@ -11,6 +20,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Hashtag extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/hashtag/service/HashtagService.java
@@ -4,36 +4,36 @@ import com.justdo.plug.post.domain.hashtag.Hashtag;
 import com.justdo.plug.post.domain.hashtag.repository.HashtagRepository;
 import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class HashtagService {
+
     private final HashtagRepository hashtagRepository;
 
-    public Long getHashtagIdByName(String hashtagName) {
+    public Hashtag getHashtagIdByName(String hashtagName) {
         Hashtag hashtag = hashtagRepository.findByName(hashtagName);
         // 만약 사용하려는 해시태그가 없다면 새로운 해시태그 생성 후 사용
-        hashtag = (hashtag == null) ? createNewHashtag(hashtagName) : hashtag;
-        return hashtag.getId();
+        return (hashtag == null) ? createNewHashtag(hashtagName) : hashtag;
     }
 
+    @Transactional
     public Hashtag createNewHashtag(String hashtagName) {
         Hashtag newHashtag = Hashtag.builder()
-                .name(hashtagName)
-                .build();
+            .name(hashtagName)
+            .build();
 
         return hashtagRepository.save(newHashtag);
     }
 
     public String getHashtagNameById(Long hashtagId) {
         Hashtag hashtag = hashtagRepository.findById(hashtagId)
-                .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
+            .orElseThrow(() -> new ApiException(ErrorStatus._HASHTAG_NOT_FOUND));
         return hashtag.getName();
     }
-
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/photo/Photo.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/Photo.java
@@ -1,27 +1,39 @@
 package com.justdo.plug.post.domain.photo;
 
 import com.justdo.plug.post.domain.common.BaseTimeEntity;
-import jakarta.persistence.*;
+import com.justdo.plug.post.domain.post.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
+public class Photo extends BaseTimeEntity {
 
-public class Photo extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long photoId;
 
-    @Column(nullable = true)
+    @Column
     private String photoUrl;
 
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    public Photo(String photoUrl, Post post) {
+        this.photoUrl = photoUrl;
+        this.post = post;
+    }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
@@ -2,6 +2,7 @@ package com.justdo.plug.post.domain.photo.service;
 
 import com.justdo.plug.post.domain.photo.Photo;
 import com.justdo.plug.post.domain.photo.repository.PhotoRepository;
+import com.justdo.plug.post.domain.post.Post;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,16 +11,10 @@ import org.springframework.stereotype.Service;
 @Transactional
 @RequiredArgsConstructor
 public class PhotoService {
+
     private final PhotoRepository photoRepository;
 
-    public void createPhoto(String photoUrl, Long postId){
-        Photo photo = new Photo();
-        photo.setPostId(postId);
-        photo.setPhotoUrl(photoUrl);
-        save(photo);
-    }
-
-    public void save(Photo photo){
-        photoRepository.save(photo);
+    public void createPhoto(String photoUrl, Post post) {
+        photoRepository.save(new Photo(photoUrl, post));
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -2,15 +2,21 @@ package com.justdo.plug.post.domain.post.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.justdo.plug.post.domain.category.service.CategoryService;
-import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.PostRequestDto;
 import com.justdo.plug.post.domain.post.dto.PostResponseDto;
 import com.justdo.plug.post.domain.post.dto.PostSearchDTO;
+import com.justdo.plug.post.domain.post.dto.PreviewResponse;
+import com.justdo.plug.post.domain.post.dto.PreviewResponse.BlogPostItem;
+import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItem;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemList;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
@@ -24,14 +30,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
+@Tag(name = "Post API")
 @RestController
 @RequestMapping("/posts/")
 @RequiredArgsConstructor
-/*BLOG API - POSTS*/
 public class PostController {
 
-    private final HashtagService hashtagService;
     private final PostHashtagService postHashtagService;
     private final PostService postService;
     private final CategoryService categoryService;
@@ -39,7 +43,7 @@ public class PostController {
 
 
     // BLOG001: 게시글 리스트 조회 요청
-    @GetMapping()
+    @GetMapping
     public List<Post> ViewList() {
 
         return postService.getAllPosts();
@@ -56,31 +60,32 @@ public class PostController {
 
     // BLOG003: 게시글 작성 요청
     @PostMapping("{blogId}")
-    public String PostBlog(@RequestBody PostRequestDto RequestDto, @PathVariable Long blogId)
+    public String PostBlog(@RequestBody PostRequestDto requestDto, @PathVariable Long blogId)
         throws JsonProcessingException {
 
         // 1. Post 저장
-        RequestDto.setBlogId(blogId);
+        requestDto.setBlogId(blogId);
+
         // 1-2. Preview 저장
-        String content = RequestDto.getContent();
-        String preview = postService.savePreviewPost(content);
-        RequestDto.setPreview(preview);
-        Post post = postService.save(RequestDto);
+        String content = requestDto.getContent();
+        String preview = postService.parseContent(content);
+        requestDto.setPreview(preview);
+        Post post = postService.save(requestDto);
 
         // Post 에서 post_id 받아오기
         Long postId = post.getId();
 
         // 2. Post_Hashtag 저장
-        List<String> hashtags = RequestDto.getHashtags();
-        postHashtagService.createHashtag(hashtags, postId);
+        List<String> hashtags = requestDto.getHashtags();
+        postHashtagService.createHashtag(hashtags, post);
 
         // 3. Category 저장
-        String name = RequestDto.getName(); // '카테고리 명'저장
+        String name = requestDto.getName(); // '카테고리 명'저장
         categoryService.createCategory(name, postId);
 
         // 4. Photo 저장
-        String photoUrl = RequestDto.getPhotoUrl();
-        photoService.createPhoto(photoUrl, postId);
+        String photoUrl = requestDto.getPhotoUrl();
+        photoService.createPhoto(photoUrl, post);
 
         return "게시글이 성공적으로 업로드 되었습니다";
     }
@@ -99,16 +104,9 @@ public class PostController {
         return null;
     }
 
-    // BLOG006: 블로그 게시글 리스트 조회 요청
-    @GetMapping("blog/{blogId}")
-    public List<Post> ViewBlogList(@PathVariable Long blogId) {
-
-        return postService.getBlogPosts(blogId);
-    }
-
     // BlOG007: 특정 멤버가 사용한 HASHTAG 값 조회
     @GetMapping("memberId/{memberId}")
-    public List<String> ViewHashtags(@PathVariable Long memberId){
+    public List<String> ViewHashtags(@PathVariable Long memberId) {
 
         return postHashtagService.getHashtags(memberId);
 
@@ -122,7 +120,7 @@ public class PostController {
 
     }
 
-    // GLUE252 : 블로그의 포스트 preview 반환
+    @Operation(summary = "Post 미리보기에서 내가 구독한 사용자 포스트 조회 요청 (구독 페이지)", description = "Open Feign을 통해 사용되는 API입니다.")
     @PostMapping("preview")
     public PostItemList findPreviewByBlogIds(@RequestBody List<Long> blogIdList,
         @RequestParam int page) {
@@ -131,20 +129,39 @@ public class PostController {
     }
 
     @PostMapping("preview/subscribers")
+    @Operation(summary = "Post 미리보기에서 나를 구독한 사용자 포스트 조회 요청 (구독 페이지)", description = "Open Feign을 통해 사용되는 API입니다.")
     public PostItemList findPreviewByMemberIds(@RequestBody List<Long> memberIdList,
         @RequestParam int page) {
 
         return postService.findPreviewsByMember(memberIdList, page);
     }
-  
+
+    /**
+     * 포스트 목록 조회 (개인 블로그 조회 페이지) -> open feign
+     */
+    @Operation(summary = "최신 Post 4개 조회 요청", description = "Open Feign을 통해 사용되는 API입니다.")
+    @Parameter(name = "blogId", description = "블로그의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
+    @GetMapping("blogs/{blogId}")
+    public BlogPostItem findBlogPosts(@PathVariable Long blogId) {
+
+        List<Post> recent4Post = postService.getRecent4Post(blogId);
+
+        List<PostItem> postItemList = postService.getPostItemList(recent4Post);
+        List<String> hashtagNames = postHashtagService.getHashtagNamesByPost(recent4Post);
+
+        return PreviewResponse.toBlogPostItem(postItemList, hashtagNames);
+    }
+
     // BLOG009: 블로그 아이디로 해시태그 추출하기
     @GetMapping("blogId/{blogId}")
-    public List<String> ViewHashtagsBlog(@PathVariable Long blogId){
+    public List<String> ViewHashtagsBlog(@PathVariable Long blogId) {
         return postHashtagService.getHashtagsBlog(blogId);
 
     }
-    
-    // kylo es 
+
+    // kylo ES
+    @Operation(summary = "Post 검색 요청", description = "Post의 title, content, hashtagName을 기반으로 검색을 진행합니다.")
+    @Parameter(name = "keyword", description = "keyword는 검색어이며, QueryString 입니다.", required = true, example = "종강", in = ParameterIn.QUERY)
     @GetMapping("search")
     public List<PostSearchDTO> searchElastic(@RequestParam String keyword) {
 

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
@@ -56,4 +56,22 @@ public class PreviewResponse {
             .build();
 
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class BlogPostItem {
+
+        private List<PostItem> postItems;
+        private List<String> hashtagNames;
+    }
+
+    public static BlogPostItem toBlogPostItem(List<PostItem> postItems, List<String> hashtagNames) {
+
+        return BlogPostItem.builder()
+            .postItems(postItems)
+            .hashtagNames(hashtagNames)
+            .build();
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -13,6 +13,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByBlogId(Long blogId);
 
+    List<Post> findTop4ByBlogIdOrderByCreatedAtDesc(Long blogId);
+
     List<Post> findByMemberId(Long memberId);
 
     @Query("SELECT p FROM Post p WHERE p.blogId in :blogIdList")

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/PostHashtag.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/PostHashtag.java
@@ -1,7 +1,15 @@
 package com.justdo.plug.post.domain.posthashtag;
 
 import com.justdo.plug.post.domain.common.BaseTimeEntity;
-import jakarta.persistence.*;
+import com.justdo.plug.post.domain.hashtag.Hashtag;
+import com.justdo.plug.post.domain.post.Post;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,14 +21,21 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostHashtag extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postHashtagId;
 
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 
-    @Column(nullable = false)
-    private Long hashtagId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtag_id", nullable = false)
+    private Hashtag hashtag;
 
+    public PostHashtag(Post post, Hashtag hashtag) {
+        this.post = post;
+        this.hashtag = hashtag;
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/repository/PostHashtagRepository.java
@@ -1,7 +1,9 @@
 package com.justdo.plug.post.domain.posthashtag.repository;
 
+import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,7 @@ import java.util.List;
 @Repository
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long>{
     List<PostHashtag> findByPostId(Long postId);
+
+    @Query("SELECT ph FROM PostHashtag ph WHERE ph.post IN :postList")
+    List<PostHashtag> findByPostList(List<Post> postList);
 }


### PR DESCRIPTION
## 📌 요약

- 개인 블로그에 보이는 최신순 Post 조회 API 구현

## 📝 상세 내용

- 최신순 Post 4개를 조회하였습니다.
- hashtag 값도 일단은 4개의 포스트에 해당하는 최신 해시태그를 전달하였습니다.

## 🗣️ 질문 및 이외 사항

- 희찬이 코드에서 Entity 설정과 Transcational 코드를 잘못 설정하여 수정사항이 많습니다. 참고바랍니다.

## ☑️ 이슈 번호

- close #
