### PR TITLE
GLUE-148 : feat: ElasticSearch 게시글 삭제 API

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
@@ -1,9 +1,13 @@
 package com.justdo.plug.post.domain.photo.repository;
 import com.justdo.plug.post.domain.photo.Photo;
+import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long>{
 
+    List<Photo> findByPostId(Long postId);
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/Post.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/Post.java
@@ -46,7 +46,7 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String preview;
 
-    @Column
+    @Column(nullable = false, updatable = false)
     private String esId;
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -93,10 +93,9 @@ public class PostController {
     }
 
     // BLOG005: 게시글 삭제 요청
-    @DeleteMapping("{postId}")
-    public PostRequestDto DeleteBlog(@PathVariable Long postId) {
-        /*service*/
-        return null;
+    @GetMapping("delete/{id}")
+    public String deletePost(@PathVariable String id){
+        return postService.deletePost(id);
     }
 
     // BLOG006: 블로그 게시글 리스트 조회 요청
@@ -147,9 +146,9 @@ public class PostController {
     // kylo es 
     @GetMapping("search")
     public List<PostSearchDTO> searchElastic(@RequestParam String keyword) {
-
         return postService.searchPost(keyword);
     }
+
 
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.justdo.plug.post.domain.post.repository;
 
 import com.justdo.plug.post.domain.post.Post;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,9 +17,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByMemberId(Long memberId);
 
+    Optional<Post> findByEsId(String esId);
+
     @Query("SELECT p FROM Post p WHERE p.blogId in :blogIdList")
     Slice<Post> findByBlogIdList(List<Long> blogIdList, PageRequest pageRequest);
 
     @Query("SELECT p FROM Post p WHERE p.memberId in :memberIdList")
     Slice<Post> findByMemberIdList(List<Long> memberIdList, PageRequest pageRequest);
+
 }


### PR DESCRIPTION
## 📌 요약

- 게시글 삭제 요청 API 입니다. 

## 📝 상세 내용

- 일단 ElasticSearch에 있는 게시글을 ESId로 삭제 할수 있도록 함

<img width="1084" alt="Screenshot 2024-05-11 at 1 09 10 AM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/ba002c96-fd4e-46a4-9153-8aeaafc13903">

- MySQL 디비 값들도 지울수 있도록 코드는 완성 -> MySQL 분리후 주석 해제 예정(코드는 돌아가는 것 확인 완료)


## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
