### PR TITLE
Glue 293 Feat: 내 블로그 Stories 및 전체글 조회 API 구현

### DIFF
--- a/.github/workflows/post-server.yaml
+++ b/.github/workflows/post-server.yaml
@@ -22,6 +22,14 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set environment yml file
+        run: |
+          mkdir ./src/main/resources
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.APPLICATION }}" >> ./application.yml
+        shell: bash
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application.yml

--- a/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
@@ -1,9 +1,11 @@
 package com.justdo.plug.post.domain.photo.repository;
+
 import com.justdo.plug.post.domain.photo.Photo;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PhotoRepository extends JpaRepository<Photo, Long>{
-
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    Optional<Photo> findFirstByPostId(Long postId);
 }

--- a/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
@@ -4,6 +4,7 @@ import com.justdo.plug.post.domain.photo.Photo;
 import com.justdo.plug.post.domain.photo.repository.PhotoRepository;
 import com.justdo.plug.post.domain.post.Post;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,20 @@ public class PhotoService {
 
     public void createPhoto(String photoUrl, Post post) {
         photoRepository.save(new Photo(photoUrl, post));
+    }
+
+    public String findPhotoByPostId(Long postId) {
+
+        return photoRepository.findFirstByPostId(postId)
+            .map(Photo::getPhotoUrl)
+            .orElse(null);
+
+    }
+
+    public List<String> findPhotoUrlsByPosts(List<Post> posts) {
+
+        return posts.stream()
+            .map(post -> findPhotoByPostId(post.getId()))
+            .toList();
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostSearchDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostSearchDTO.java
@@ -1,21 +1,32 @@
 package com.justdo.plug.post.domain.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "검색 응답 DTO")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class PostSearchDTO {
 
+    @Schema(description = "Post 아이디")
     private Long postId;
+
+    @Schema(description = "Post 제목 ")
     private String title;
+
+    @Schema(description = "Post Preview : 포스트 글 부분")
     private String preview;
+
+    @Schema(description = "Post가 작성된 Blog 아이디")
     private Long blogId;
+
+    @Schema(description = "작성자 Member Id")
     private Long memberId;
+
+    @Schema(description = "ES 관련 데이터")
     private String _class;
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
@@ -1,54 +1,85 @@
 package com.justdo.plug.post.domain.post.dto;
 
 import com.justdo.plug.post.domain.post.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 
 public class PreviewResponse {
 
+    @Schema(description = "Post 미리보기 응답 DTO")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
     public static class PostItem {
 
+        @Schema(description = "Post 아이디")
         private Long postId;
+
+        @Schema(description = "Post 제목")
         private String title;
+
+        @Schema(description = "Post 글 미리보기")
         private String preview;
-        private String photo;
+
+        @Schema(description = "Post의 추가된 사진 경로")
+        private String photoUrl;
     }
 
-    public static PostItem toPostItem(Post post) {
+    public static PostItem toPostItem(Post post, String photoUrl) {
         return PostItem.builder()
             .postId(post.getId())
             .title(post.getTitle())
             .preview(post.getPreview()) // TODO : 포스트의 Photo 추가
+            .photoUrl(photoUrl)
             .build();
+    }
+
+    public static List<PostItem> toPostItemList(List<Post> posts, List<String> photoUrls) {
+
+        return IntStream.range(0, posts.size())
+            .mapToObj(idx -> {
+                return toPostItem(posts.get(idx), photoUrls.get(idx));
+            })
+            .toList();
     }
 
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class PostItemList {
+    public static class PostItemSlice {
 
         private List<PostItem> postItems;
+
+        @Schema(description = "다음 페이지의 여부")
         private boolean hasNext;
+
+        @Schema(description = "첫 페이지의 여부")
         private boolean hasFirst;
+
+        @Schema(description = "마지막 페이지의 여부")
         private boolean hasLast;
     }
 
-    public static PostItemList toPostItemList(Slice<Post> posts) {
+    public static PostItemSlice toPostItemSlice(Slice<Post> posts, List<String> photoUrls) {
 
-        List<PostItem> postItems = posts.stream()
-            .map(PreviewResponse::toPostItem)
+        List<Post> postList = posts.getContent();
+
+        List<PostItem> postItems = IntStream.range(0, postList.size())
+            .mapToObj(idx -> {
+                return toPostItem(postList.get(idx), photoUrls.get(idx));
+            })
             .toList();
 
-        return PostItemList.builder()
+        return PostItemSlice.builder()
             .postItems(postItems)
             .hasNext(posts.hasNext())
             .hasFirst(posts.isFirst())
@@ -57,6 +88,52 @@ public class PreviewResponse {
 
     }
 
+    @Schema(description = "내 블로그 전체글 응답 DTO")
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class StoryItem {
+
+        private List<PostItem> postItems;
+
+        @Schema(description = "페이징 된 리스트의 항목 개수")
+        private Integer listSize;
+
+        @Schema(description = "총 페이징 수")
+        private Integer totalPage;
+
+        @Schema(description = "전체 데이터의 개수")
+        private Long totalElements;
+
+        @Schema(description = "첫 페이지의 여부")
+        private Boolean isFirst;
+
+        @Schema(description = "마지막 페이지의 여부")
+        private Boolean isLast;
+    }
+
+    public static StoryItem toStoryItem(Page<Post> posts, List<String> photoUrls) {
+
+        List<Post> postList = posts.getContent();
+
+        List<PostItem> postItems = IntStream.range(0, postList.size())
+            .mapToObj(idx -> {
+                return toPostItem(postList.get(idx), photoUrls.get(idx));
+            })
+            .toList();
+
+        return StoryItem.builder()
+            .postItems(postItems)
+            .listSize(postItems.size())
+            .totalPage(posts.getTotalPages())
+            .totalElements(posts.getTotalElements())
+            .isFirst(posts.isFirst())
+            .isLast(posts.isLast())
+            .build();
+    }
+
+    @Schema(description = "내 블로그의 Post, Hashtag 정보 응답 DTO")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -64,6 +141,8 @@ public class PreviewResponse {
     public static class BlogPostItem {
 
         private List<PostItem> postItems;
+
+        @Schema(description = "Post에 작성된 해시태그 목록")
         private List<String> hashtagNames;
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.justdo.plug.post.domain.post.repository;
 
 import com.justdo.plug.post.domain.post.Post;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByBlogId(Long blogId);
 
     List<Post> findTop4ByBlogIdOrderByCreatedAtDesc(Long blogId);
+
+    Page<Post> findAllByBlogId(Long blogId, PageRequest pageRequest);
 
     List<Post> findByMemberId(Long memberId);
 


### PR DESCRIPTION
## 📌 요약

-  내 블로그 Stories 및 전체 글 조회 API 구현

## 📝 상세 내용

- 내 블로그 페이지에서 Stories, Hashtag 부분에서 최신 Post 4개의 글을 기준으로 응답
- 전체 글 조회 시, 최신 Post 순으로 7개씩 전달. (포스트 글만 전달하는 API 따로 만들었는데, Front에서 처리 가능한지 궁금합니다.)

## 🗣️ 질문 및 이외 사항

<img width="454" alt="image" src="https://github.com/DoTheZ-Team/post-service/assets/103489352/d7f9c53b-44d1-48f0-861e-7ca8ade64e2f">

> 위 Stories 부분을 따로 컴포넌트화 해서 API 요청 따로 보내면서, 기존 왼쪽 바에 있는 정보는 유지 가능한지 궁금합니다. @yeyounging 

## ☑️ 이슈 번호

- close #
