### PR TITLE
Glue 307 Feat: Post 댓글 CRUD 구현

### DIFF
--- a/src/main/java/com/justdo/plug/post/PostApplication.java
+++ b/src/main/java/com/justdo/plug/post/PostApplication.java
@@ -1,9 +1,11 @@
 package com.justdo.plug.post;
 
+import com.justdo.plug.post.global.config.SwaggerConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -12,12 +14,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableFeignClients
 @EnableJpaRepositories(basePackages = "com.justdo.plug.post.domain")
 @EnableElasticsearchRepositories(basePackages = "com.justdo.plug.post.elastic")
-@ComponentScan(basePackages = {"com.justdo.plug.post.elastic", "com.justdo.plug.post.domain"})
+@ComponentScan(basePackages = {"com.justdo.plug.post.elastic", "com.justdo.plug.post.domain",
+        "com.justdo.plug.post.global.exception"})
 @SpringBootApplication
+@Import(SwaggerConfig.class)
 public class PostApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(PostApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(PostApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
@@ -1,5 +1,6 @@
 package com.justdo.plug.post.domain.blog;
 
+import com.justdo.plug.post.domain.blog.BlogDto.BlogInfo;
 import com.justdo.plug.post.domain.post.dto.SearchResponse.BlogInfoItem;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -13,4 +14,7 @@ public interface BlogClient {
     @PostMapping("/search")
     BlogInfoItem findBlogInfoItem(@RequestBody List<Long> blogIdList,
         @RequestParam(value = "page", defaultValue = "0") int page);
+
+    @PostMapping("/comments")
+    List<BlogInfo> findBlogInfoToComment(@RequestBody List<Long> memberIdList);
 }

--- a/src/main/java/com/justdo/plug/post/domain/blog/BlogDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/blog/BlogDto.java
@@ -1,0 +1,19 @@
+package com.justdo.plug.post.domain.blog;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+public class BlogDto {
+
+    @Schema(description = "댓글의 블로그 정보 Request DTO - Open Feign으로부터 받음")
+    @Getter
+    public static class BlogInfo {
+
+        @Schema(description = "블로그 프로필")
+        private String profile;
+
+        @Schema(description = "블로그 제목")
+        private String title;
+    }
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/Comment.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/Comment.java
@@ -1,5 +1,59 @@
 package com.justdo.plug.post.domain.comment;
 
-public class Comment {
+import com.justdo.plug.post.domain.common.BaseTimeEntity;
+import com.justdo.plug.post.domain.post.Post;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id", nullable = false)
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Comment> children = new ArrayList<>();
+
+    /**
+     * update
+     */
+    public void update(String content) {
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/comment/Comment.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/Comment.java
@@ -43,7 +43,7 @@ public class Comment extends BaseTimeEntity {
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_comment_id", nullable = false)
+    @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
     @OneToMany(mappedBy = "parentComment", orphanRemoval = true, cascade = CascadeType.ALL)

--- a/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,7 +30,7 @@ public class CommentController {
     @Parameter(name = "postId", description = "포스트의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
     @PostMapping("/{postId}")
     public ApiResponse<CommentProc> post(HttpServletRequest request, @RequestBody
-            CommentRequest.PostComment post, @PathVariable Long postId) {
+    CommentRequest.PostComment post, @PathVariable Long postId) {
 
         // TODO: JwtProvider 추가 후 수정
         Long memberId = 1L;
@@ -37,4 +38,15 @@ public class CommentController {
 
         return ApiResponse.onSuccess(commentService.writeComment(commentVO));
     }
+
+    @Operation(summary = "댓글 페이지 - 게시글에 댓글 수정 API", description = "Post의 Comment를 수정합니다.")
+    @Parameter(name = "commentId", description = "댓글의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
+    @PatchMapping("/{commentId}")
+    public ApiResponse<CommentProc> patch(HttpServletRequest request, @PathVariable Long commentId,
+            @RequestBody String content) {
+
+        return ApiResponse.onSuccess(commentService.patchComment(commentId, content));
+    }
+
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
@@ -1,21 +1,28 @@
 package com.justdo.plug.post.domain.comment.controller;
 
 import com.justdo.plug.post.domain.comment.dto.CommentRequest;
+import com.justdo.plug.post.domain.comment.dto.CommentResponse;
 import com.justdo.plug.post.domain.comment.dto.CommentResponse.CommentProc;
 import com.justdo.plug.post.domain.comment.dto.CommentVO;
 import com.justdo.plug.post.domain.comment.service.CommentService;
 import com.justdo.plug.post.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post Comment 댓글 관련 API입니다.")
@@ -26,7 +33,41 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @Operation(summary = "댓글 페이지 - 게시글에 댓글 작성 API", description = "Post의 Comment를 작성합니다.")
+    @Operation(summary = "댓글 조회 페이지 - 게시글에 작성된 부모 댓글 조회 API", description = "Post의 Comment 목록을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "postId", description = "포스트의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH),
+            @Parameter(name = "page", description = "페이징 번호 page, Query String입니다.", in = ParameterIn.QUERY),
+            @Parameter(name = "size", description = "페이징 크기 size, Query String입니다.", in = ParameterIn.QUERY)
+    })
+    @GetMapping("/{postId}")
+    public ApiResponse<CommentResponse.CommentResult> getComments(@PathVariable Long postId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt"));
+
+        return ApiResponse.onSuccess(commentService.findComments(postId, pageRequest));
+    }
+
+    /**
+     * TODO: 대댓글 조회 "/posts/comments/{commentId}"
+     */
+    @Operation(summary = "댓글 조회 페이지 - 게시글에 작성된 특정 댓글의 자식 댓글 조회 API", description = "Post의 자식 Comment 목록을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "page", description = "페이징 번호 page, Query String입니다.", in = ParameterIn.QUERY),
+            @Parameter(name = "size", description = "페이징 크기 size, Query String입니다.", in = ParameterIn.QUERY)
+    })
+    @GetMapping("/childs/{commentId}")
+    public ApiResponse<CommentResponse.CommentResult> getChildComments(@PathVariable Long commentId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt"));
+
+        return ApiResponse.onSuccess(commentService.findChildComments(commentId, pageRequest));
+    }
+
+    @Operation(summary = "댓글 작성 페이지 - 게시글에 댓글 작성 API", description = "Post의 Comment를 작성합니다.")
     @Parameter(name = "postId", description = "포스트의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
     @PostMapping("/{postId}")
     public ApiResponse<CommentProc> post(HttpServletRequest request, @RequestBody
@@ -39,14 +80,20 @@ public class CommentController {
         return ApiResponse.onSuccess(commentService.writeComment(commentVO));
     }
 
-    @Operation(summary = "댓글 페이지 - 게시글에 댓글 수정 API", description = "Post의 Comment를 수정합니다.")
+    @Operation(summary = "댓글 수정 페이지 - 게시글에 댓글 수정 API", description = "Post의 Comment를 수정합니다.")
     @Parameter(name = "commentId", description = "댓글의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
     @PatchMapping("/{commentId}")
-    public ApiResponse<CommentProc> patch(HttpServletRequest request, @PathVariable Long commentId,
+    public ApiResponse<CommentProc> patch(@PathVariable Long commentId,
             @RequestBody String content) {
 
         return ApiResponse.onSuccess(commentService.patchComment(commentId, content));
     }
 
+    @Operation(summary = "댓글 삭제 - 게시글에 댓글 수정 API", description = "Post의 Comment를 수정합니다.")
+    @Parameter(name = "commentId", description = "댓글의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
+    @DeleteMapping("/{commentId}")
+    public ApiResponse<CommentProc> delete(@PathVariable Long commentId) {
 
+        return ApiResponse.onSuccess(commentService.deleteComment(commentId));
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/controller/CommentController.java
@@ -1,0 +1,40 @@
+package com.justdo.plug.post.domain.comment.controller;
+
+import com.justdo.plug.post.domain.comment.dto.CommentRequest;
+import com.justdo.plug.post.domain.comment.dto.CommentResponse.CommentProc;
+import com.justdo.plug.post.domain.comment.dto.CommentVO;
+import com.justdo.plug.post.domain.comment.service.CommentService;
+import com.justdo.plug.post.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Post Comment 댓글 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 페이지 - 게시글에 댓글 작성 API", description = "Post의 Comment를 작성합니다.")
+    @Parameter(name = "postId", description = "포스트의 Id, Path Variable입니다.", required = true, in = ParameterIn.PATH)
+    @PostMapping("/{postId}")
+    public ApiResponse<CommentProc> post(HttpServletRequest request, @RequestBody
+            CommentRequest.PostComment post, @PathVariable Long postId) {
+
+        // TODO: JwtProvider 추가 후 수정
+        Long memberId = 1L;
+        CommentVO commentVO = CommentVO.of(memberId, post, postId);
+
+        return ApiResponse.onSuccess(commentService.writeComment(commentVO));
+    }
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,31 @@
+package com.justdo.plug.post.domain.comment.dto;
+
+import com.justdo.plug.post.domain.comment.Comment;
+import com.justdo.plug.post.domain.post.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+public class CommentRequest {
+
+    @Schema(description = "댓글 작성 DTO")
+    @Getter
+    public static class PostComment {
+
+        @Schema(description = "댓글 내용")
+        private String content;
+
+        @Schema(description = "부모 댓글 id / 부모 댓글인 경우, parentId 빼고 보내기!")
+        private Long parentId;
+    }
+
+    public static Comment toEntity(Long memberId, Post post, String content,
+            Comment parentComment) {
+
+        return Comment.builder()
+                .memberId(memberId)
+                .content(content)
+                .post(post)
+                .parentComment(parentComment)
+                .build();
+    }
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
@@ -1,6 +1,7 @@
 package com.justdo.plug.post.domain.comment.dto;
 
 import com.justdo.plug.post.domain.comment.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,12 +10,17 @@ import lombok.NoArgsConstructor;
 
 public class CommentResponse {
 
+    @Schema(description = "댓글 작성/수정/삭제 처리 응답 DTO")
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
     public static class CommentProc {
+
+        @Schema(description = "댓글 아이디")
         private Long commentId;
+
+        @Schema(description = "요청 처리 응답 시간")
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
@@ -1,12 +1,16 @@
 package com.justdo.plug.post.domain.comment.dto;
 
+import com.justdo.plug.post.domain.blog.BlogDto.BlogInfo;
 import com.justdo.plug.post.domain.comment.Comment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 public class CommentResponse {
 
@@ -29,6 +33,82 @@ public class CommentResponse {
         return CommentProc.builder()
                 .commentId(comment.getId())
                 .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Schema(description = "댓글 목록 응답 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CommentResult {
+
+        @Schema(description = "댓글 데이터 목록")
+        List<CommentItem> commentItems;
+
+        @Schema(description = "추가 조회할 목록이 있는지의 여부")
+        private boolean hasNext;
+
+        @Schema(description = "첫 페이지인지 여부")
+        private boolean isFirst;
+
+        @Schema(description = "마지막 페이지인지 여부")
+        private boolean isLast;
+    }
+
+    public static CommentResult toCommentResult(Slice<Comment> commentSlice,
+            List<BlogInfo> blogInfoList) {
+
+        List<Comment> commentList = commentSlice.getContent();
+        System.out.println("commentList.size() = " + commentList.size());
+        List<CommentItem> commentItems = IntStream.range(0, commentList.size())
+                .mapToObj(idx -> toCommentItem(commentList.get(idx), blogInfoList.get(idx)))
+                .toList();
+
+        return CommentResult.builder()
+                .commentItems(commentItems)
+                .hasNext(commentSlice.hasNext())
+                .isFirst(commentSlice.isFirst())
+                .isLast(commentSlice.isLast())
+                .build();
+    }
+
+    @Schema(description = "댓글 데이터 DTO")
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class CommentItem {
+
+        @Schema(description = "댓글 아이디")
+        private Long commentId;
+
+        @Schema(description = "댓글 내용")
+        private String content;
+
+        @Schema(description = "작성한 블로그 프로필")
+        private String blogProfile;
+
+        @Schema(description = "작성한 블로그 제목")
+        private String blogTitle;
+
+        @Schema(description = "댓글이 작성된 시간")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "부모 댓글 아이디 / 부모 댓글인 경우 0, 대댓글인 경우 부모 댓글의 Id")
+        private Long parentCommentId;
+    }
+
+    public static CommentItem toCommentItem(Comment comment, BlogInfo blogInfo) {
+
+        return CommentItem.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .blogProfile(blogInfo.getProfile())
+                .blogTitle(blogInfo.getTitle())
+                .createdAt(LocalDateTime.now())
+                .parentCommentId(
+                        comment.getParentComment() != null ? comment.getParentComment().getId() : 0)
                 .build();
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,29 @@
+package com.justdo.plug.post.domain.comment.dto;
+
+import com.justdo.plug.post.domain.comment.Comment;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CommentResponse {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CommentProc {
+        private Long commentId;
+        private LocalDateTime createdAt;
+    }
+
+    public static CommentProc toCommentProc(Comment comment) {
+
+        return CommentProc.builder()
+                .commentId(comment.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentResponse.java
@@ -2,6 +2,7 @@ package com.justdo.plug.post.domain.comment.dto;
 
 import com.justdo.plug.post.domain.blog.BlogDto.BlogInfo;
 import com.justdo.plug.post.domain.comment.Comment;
+import com.justdo.plug.post.global.utils.DateParser;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -80,6 +81,9 @@ public class CommentResponse {
     @Getter
     public static class CommentItem {
 
+        @Schema(description = "작성자 아이디")
+        private Long memberId;
+
         @Schema(description = "댓글 아이디")
         private Long commentId;
 
@@ -93,22 +97,29 @@ public class CommentResponse {
         private String blogTitle;
 
         @Schema(description = "댓글이 작성된 시간")
-        private LocalDateTime createdAt;
+        private String createdAt;
 
         @Schema(description = "부모 댓글 아이디 / 부모 댓글인 경우 0, 대댓글인 경우 부모 댓글의 Id")
         private Long parentCommentId;
+
+        @Schema(description = "자식 댓글 존재 여부")
+        private Boolean hasChildComment;
     }
 
     public static CommentItem toCommentItem(Comment comment, BlogInfo blogInfo) {
 
+        System.out.println("comment.getChildren() = " + comment.getChildren());
+
         return CommentItem.builder()
+                .memberId(comment.getMemberId())
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .blogProfile(blogInfo.getProfile())
                 .blogTitle(blogInfo.getTitle())
-                .createdAt(LocalDateTime.now())
+                .createdAt(DateParser.dateTimeParse(LocalDateTime.now()))
                 .parentCommentId(
                         comment.getParentComment() != null ? comment.getParentComment().getId() : 0)
+                .hasChildComment(!comment.getChildren().isEmpty())
                 .build();
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentVO.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/dto/CommentVO.java
@@ -1,0 +1,8 @@
+package com.justdo.plug.post.domain.comment.dto;
+
+public record CommentVO(Long memberId, String content, Long parentId, Long postId) {
+
+    public static CommentVO of(Long memberId, CommentRequest.PostComment post, Long postId) {
+        return new CommentVO(memberId, post.getContent(), post.getParentId(), postId);
+    }
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,13 @@
 package com.justdo.plug.post.domain.comment.repository;
 
 import com.justdo.plug.post.domain.comment.Comment;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    Slice<Comment> findAllByPostIdAndParentCommentIsNull(Long postId, PageRequest pageRequest);
+
+    Slice<Comment> findAllByParentCommentId(Long parentId, PageRequest pageRequest);
 }

--- a/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.justdo.plug.post.domain.comment.repository;
+
+import com.justdo.plug.post.domain.comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
@@ -1,0 +1,57 @@
+package com.justdo.plug.post.domain.comment.service;
+
+import com.justdo.plug.post.domain.comment.Comment;
+import com.justdo.plug.post.domain.comment.dto.CommentRequest;
+import com.justdo.plug.post.domain.comment.dto.CommentResponse;
+import com.justdo.plug.post.domain.comment.dto.CommentResponse.CommentProc;
+import com.justdo.plug.post.domain.comment.dto.CommentVO;
+import com.justdo.plug.post.domain.comment.repository.CommentRepository;
+import com.justdo.plug.post.domain.post.Post;
+import com.justdo.plug.post.domain.post.service.PostService;
+import com.justdo.plug.post.global.exception.ApiException;
+import com.justdo.plug.post.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostService postService;
+
+    @Transactional
+    public CommentProc writeComment(CommentVO commentVO) {
+        Comment comment = commentRepository.save(createComment(commentVO));
+
+        return CommentResponse.toCommentProc(comment);
+    }
+
+    private Comment createComment(CommentVO commentVO) {
+        Long memberId = commentVO.memberId();
+        Post post = postService.getPost(commentVO.postId());
+        String content = commentVO.content();
+        Long parentId = commentVO.parentId();
+
+        if (parentId != null) {
+            Comment parentComment = getParentComment(parentId);
+            return CommentRequest.toEntity(memberId, post, content, parentComment);
+        }
+        return CommentRequest.toEntity(memberId, post, content, null);
+    }
+
+    public Comment getParentComment(Long parentId) {
+
+        Comment parentComment = commentRepository.findById(parentId).orElseThrow(
+                () -> new ApiException(ErrorStatus._COMMENT_NOT_FOUND)
+        );
+
+        if (parentComment.getParentComment() != null) {
+            throw new ApiException(ErrorStatus._COMMENT_OVER_DEPTH);
+        }
+        return parentComment;
+    }
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
@@ -54,4 +54,17 @@ public class CommentService {
         return parentComment;
     }
 
+    @Transactional
+    public CommentProc patchComment(Long commentId, String content) {
+        Comment comment = getComment(commentId);
+        comment.update(content);
+        return CommentResponse.toCommentProc(comment);
+    }
+
+    public Comment getComment(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(
+                () -> new ApiException(ErrorStatus._COMMENT_NOT_FOUND)
+        );
+    }
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/justdo/plug/post/domain/common/BaseTimeEntity.java
@@ -15,10 +15,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseTimeEntity {
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -450,5 +450,10 @@ public class PostService {
         postRepository.increaseLikeCount(postId);
     }
 
+    public Post getPost(Long postId) {
+        return postRepository.findById(postId).orElseThrow(
+                () -> new ApiException(ErrorStatus._POST_NOT_FOUND)
+        );
+    }
 
 }

--- a/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/post/global/response/code/status/ErrorStatus.java
@@ -22,6 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
     //블로그
     _BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOG404", "해당 블로그를 찾을 수 없습니다."),
 
+    // 댓글
+    _COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "해당 댓글을 찾을 수 없습니다."),
+    _COMMENT_OVER_DEPTH(HttpStatus.BAD_REQUEST, "COMMENT4002", "해당 서비스는 대댓글까지만 작성할 수 있습니다."),
+
     //해시태그
     _NO_HASHTAGS(HttpStatus.NOT_FOUND, "HASHTAGS404", "해당 사용자가 사용한 해시태그를 찾을 수 없습니다."),
 

--- a/src/main/java/com/justdo/plug/post/global/utils/DateParser.java
+++ b/src/main/java/com/justdo/plug/post/global/utils/DateParser.java
@@ -1,0 +1,16 @@
+package com.justdo.plug.post.global.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateParser {
+
+    public static String dateTimeParse(LocalDateTime now) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd a h:mm분");
+
+        String formatDate = now.format(formatter);
+
+        return formatDate.replace("AM", "오전").replace("PM", "오후");
+    }
+}


### PR DESCRIPTION
## 📌 요약

- Post 댓글 CRUD 구현

## 📝 상세 내용

-

## 🗣️ 질문 및 이외 사항

- 희찬이 코드 Merge 후 JwtProvider 적용하여 memberId 불러오는 코드로 수정할 예정
- 댓글 작성 시 부모 댓글, 자식 댓글 하나의 API로 처리

<img width="571" alt="image" src="https://github.com/DoTheZ-Team/post-service/assets/103489352/df7fd41a-78ca-4bac-8515-6d6ca6919853">

<img width="593" alt="image" src="https://github.com/DoTheZ-Team/post-service/assets/103489352/5255bd51-5e4c-4c96-b771-343c26aa5bba">

1. 일반(부모) 댓글인 경우 content 값만 보내면 될 것 같습니다.
2. 자식 댓글인 경우 content, parentId 2개 값 보내면 될 것 같습니다.

@Collection50 


## ☑️ 이슈 번호

- close #
