### PR TITLE
Glue 315/feat hashtag dto

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
@@ -11,7 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Like 게시글 좋아요 관련 API입니다")
+@Tag(name = "Like 게시글 좋아요 관련 API입니다.")
 @RestController
 @RequestMapping("/posts/")
 @RequiredArgsConstructor

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -81,7 +81,7 @@ public class PostController {
         photoService.createPhoto(requestDto.getPhotoUrls(), post);
 
         // 5. Recommend Service 로 해시태그 보내주기
-        postHashtagService.sendNewHashtags(memberId, requestDto.getHashtags());
+        postHashtagService.sendNewHashtags(memberId, requestDto.getHashtags(), request);
 
         return ApiResponse.onSuccess("게시글이 성공적으로 업로드 되었습니다");
     }
@@ -96,8 +96,7 @@ public class PostController {
 
         // 전체 해시태그 Recommend Service 로 보내주기
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        List<String> hashtags = postHashtagService.getHashtags(memberId);
-        postHashtagService.sendAllHashtags(memberId, hashtags);
+        postHashtagService.sendAllHashtags(memberId, request);
 
         return ApiResponse.onSuccess(postService.UpdatePost(esId, updateDto));
     }
@@ -109,8 +108,7 @@ public class PostController {
     public ApiResponse<String> deletePost(HttpServletRequest request, @PathVariable String esId) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        List<String> hashtags = postHashtagService.getHashtags(memberId);
-        postHashtagService.sendAllHashtags(memberId, hashtags);
+        postHashtagService.sendAllHashtags(memberId, request);
 
         return ApiResponse.onSuccess(postService.deletePost(esId));
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -18,20 +18,13 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Post 게시글 관련 API입니다.")
 @RestController
@@ -97,9 +90,14 @@ public class PostController {
     @PatchMapping("{esId}")
     @Operation(summary = "특정게시글 수정 요청", description = "해당 게시글을 수정합니다")
     @Parameter(name = "esId", description = "포스트의 elasticsearch id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> EditBlog(@PathVariable String esId,
+    public ApiResponse<String> EditBlog(HttpServletRequest request, @PathVariable String esId,
             @RequestBody PostUpdateDto updateDto)
             throws JsonProcessingException {
+
+        // 전체 해시태그 Recommend Service 로 보내주기
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        List<String> hashtags = postHashtagService.getHashtags(memberId);
+        postHashtagService.sendAllHashtags(memberId, hashtags);
 
         return ApiResponse.onSuccess(postService.UpdatePost(esId, updateDto));
     }
@@ -108,7 +106,12 @@ public class PostController {
     @DeleteMapping("{esId}")
     @Operation(summary = "특정게시글 삭제 요청", description = "해당 게시글을 삭제합니다")
     @Parameter(name = "esId", description = "포스트의 elasticsearch id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> deletePost(@PathVariable String esId) {
+    public ApiResponse<String> deletePost(HttpServletRequest request, @PathVariable String esId) {
+
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        List<String> hashtags = postHashtagService.getHashtags(memberId);
+        postHashtagService.sendAllHashtags(memberId, hashtags);
+
         return ApiResponse.onSuccess(postService.deletePost(esId));
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -4,14 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.justdo.plug.post.domain.category.service.CategoryService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
-import com.justdo.plug.post.domain.post.dto.PostRequestDto;
-import com.justdo.plug.post.domain.post.dto.PostResponseDto;
-import com.justdo.plug.post.domain.post.dto.PostUpdateDto;
-import com.justdo.plug.post.domain.post.dto.PreviewResponse;
+import com.justdo.plug.post.domain.post.dto.*;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.BlogPostItem;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItem;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemSlice;
-import com.justdo.plug.post.domain.post.dto.SearchResponse;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import com.justdo.plug.post.global.response.ApiResponse;
@@ -90,6 +86,9 @@ public class PostController {
 
         // 4. Photo 저장
         photoService.createPhoto(requestDto.getPhotoUrls(), post);
+
+        // 5. Recommend Service 로 해시태그 보내주기
+        postHashtagService.sendNewHashtags(memberId, requestDto.getHashtags());
 
         return ApiResponse.onSuccess("게시글이 성공적으로 업로드 되었습니다");
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/HashtagRequestDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/HashtagRequestDTO.java
@@ -1,0 +1,15 @@
+package com.justdo.plug.post.domain.post.dto;
+
+import lombok.Data;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Data
+public class HashtagRequestDTO {
+
+    private Long memberId;
+    private List<String> hashtags;
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -1,21 +1,27 @@
 package com.justdo.plug.post.domain.posthashtag.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.justdo.plug.post.domain.hashtag.Hashtag;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.post.Post;
-import com.justdo.plug.post.domain.post.dto.HashtagRequestDTO;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import com.justdo.plug.post.domain.posthashtag.repository.PostHashtagRepository;
 import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
+import com.justdo.plug.post.global.utils.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,6 +31,13 @@ public class PostHashtagService {
     private final PostHashtagRepository postHashtagRepository;
     private final HashtagService hashtagService;
     private final PostRepository postRepository;
+    private final JwtProvider jwtProvider;
+
+    @Value("${elasticsearch.api-key}")
+    private String apiKey;
+
+    @Value("${recommend-url}")
+    private String recUrl;
 
     /**
      * Hashtag 생성
@@ -154,23 +167,75 @@ public class PostHashtagService {
         postHashtagRepository.deleteAll(postHashtags);
     }
 
-    public void sendNewHashtags(Long memberId, List<String> hashtags){
-        HashtagRequestDTO hashtagRequestdto = new HashtagRequestDTO();
+    public void sendNewHashtags(Long memberId, List<String> hashtags, HttpServletRequest request) {
 
-        hashtagRequestdto.setHashtags(hashtags);
-        hashtagRequestdto.setMemberId(memberId);
+        String updateURL = recUrl + "/recommends/update";
+        String jsonBody;
+        ObjectMapper objectMapper = new ObjectMapper();
 
-        //TODO: Recommend Service 로 POST API 요청하기
+        String token = jwtProvider.parseToken(request);
+        try {
+            Map<String, Object> docFields = new HashMap<>();
+            docFields.put("newHashtag", hashtags);
+            docFields.put("memberId", memberId);
 
+            jsonBody = objectMapper.writeValueAsString(docFields);
+            HttpRequest updateRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(updateURL))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + token)
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> updateResponse = client.send(updateRequest,
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (updateResponse.statusCode() == 200) {
+                System.out.println("업데이트 완료");
+            } else {
+                System.out.println("업데이트 도중 오류가 발생하였습니다: " + updateResponse);
+            }
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
-    public void sendAllHashtags(Long memberId, List<String> hashtags){
-        HashtagRequestDTO hashtagRequestdto = new HashtagRequestDTO();
+    public void sendAllHashtags(Long memberId, HttpServletRequest request){
 
-        hashtagRequestdto.setHashtags(hashtags);
-        hashtagRequestdto.setMemberId(memberId);
+        List<String> hashtags = getHashtags(memberId);
 
-        //TODO: Recommend Service 로 POST API 요청하기
+        String updateURL = recUrl + "/recommends/edit";
+        String jsonBody;
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String token = jwtProvider.parseToken(request);
+        try {
+            Map<String, Object> docFields = new HashMap<>();
+            docFields.put("changedHashtag", hashtags);
+            docFields.put("memberId", memberId);
+
+            jsonBody = objectMapper.writeValueAsString(docFields);
+            System.out.println("jsonBody = " + jsonBody);
+            HttpRequest updateRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(updateURL))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + token)
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+
+            HttpClient client = HttpClient.newHttpClient();
+            HttpResponse<String> updateResponse = client.send(updateRequest,
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (updateResponse.statusCode() == 200) {
+                System.out.println("업데이트 완료");
+            } else {
+                System.out.println("업데이트 도중 오류가 발생하였습니다: " + updateResponse);
+            }
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
 
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -3,6 +3,7 @@ package com.justdo.plug.post.domain.posthashtag.service;
 import com.justdo.plug.post.domain.hashtag.Hashtag;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.post.Post;
+import com.justdo.plug.post.domain.post.dto.HashtagRequestDTO;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import com.justdo.plug.post.domain.posthashtag.repository.PostHashtagRepository;
@@ -150,5 +151,15 @@ public class PostHashtagService {
     public void deletePostHashtags(Long postId) {
         List<PostHashtag> postHashtags = postHashtagRepository.findByPostId(postId);
         postHashtagRepository.deleteAll(postHashtags);
+    }
+
+    public void sendNewHashtags(Long memberId, List<String> hashtags){
+        HashtagRequestDTO hashtagRequestdto = new HashtagRequestDTO();
+
+        hashtagRequestdto.setHashtags(hashtags);
+        hashtagRequestdto.setMemberId(memberId);
+
+        //TODO: Recommend Service 로 POST API 요청하기
+
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -9,12 +9,13 @@ import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import com.justdo.plug.post.domain.posthashtag.repository.PostHashtagRepository;
 import com.justdo.plug.post.global.exception.ApiException;
 import com.justdo.plug.post.global.response.code.status.ErrorStatus;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -162,4 +163,16 @@ public class PostHashtagService {
         //TODO: Recommend Service 로 POST API 요청하기
 
     }
+
+    public void sendAllHashtags(Long memberId, List<String> hashtags){
+        HashtagRequestDTO hashtagRequestdto = new HashtagRequestDTO();
+
+        hashtagRequestdto.setHashtags(hashtags);
+        hashtagRequestdto.setMemberId(memberId);
+
+        //TODO: Recommend Service 로 POST API 요청하기
+
+    }
+
+
 }

--- a/src/main/java/com/justdo/plug/post/global/utils/JwtProvider.java
+++ b/src/main/java/com/justdo/plug/post/global/utils/JwtProvider.java
@@ -30,7 +30,7 @@ public class JwtProvider {
         return validateToken(accessToken);
     }
 
-    private String parseToken(HttpServletRequest request) {
+    public String parseToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
         if (bearerToken == null || !bearerToken.startsWith(TOKEN_PREFIX)) {
             throw new ApiException(ErrorStatus._JWT_NOT_FOUND);


### PR DESCRIPTION
## 📌 요약

- 사용자가 해시태그 추가/삭제/변경 시 Recommend Service로 해시태그 리스트를 전송합니다

## 📝 상세 내용

- 해시태그 생성시(게시글 생성시): Recommend에게 Post Method로 추가된 해시태그와 멤버 아이디 전송
- 해시태그 수정/삭제시(게시글 수정/삭제시): Recommend에게 멤버아이디가 가진 모든 해시태그 리스트(변경된)를 전송합니다

## 🗣️ 질문 및 이외 사항

- 주애가 만든 Recommend 서버와 확인완료
- **Post Service 끝**

## ☑️ 이슈 번호

- close #
