### PR TITLE
Glue 318/chore 게시글 좋아요 및 조회 로직 수정

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
@@ -17,4 +17,7 @@ public interface BlogClient {
 
     @PostMapping("/comments")
     List<BlogInfo> findBlogInfoToComment(@RequestBody List<Long> memberIdList);
+
+    @PostMapping("/subscriptions")
+    boolean checkSubscribeById(@RequestBody SubscriptionRequest.LoginSubscription loginSubscription);
 }

--- a/src/main/java/com/justdo/plug/post/domain/blog/SubscriptionRequest.java
+++ b/src/main/java/com/justdo/plug/post/domain/blog/SubscriptionRequest.java
@@ -1,0 +1,20 @@
+package com.justdo.plug.post.domain.blog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+public class SubscriptionRequest {
+
+    @Schema(description = "로그인한 사용자의 정보와 블로그의 정보 DTO")
+    @Getter
+    @Setter
+    public static class LoginSubscription {
+
+        @Schema(description = "로그인한 사용자의 아이디")
+        private Long memberId;
+
+        @Schema(description = "포스트가 작성된 블로그의 아이디")
+        private Long blogId;
+    }
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
@@ -31,17 +31,5 @@ public class LikesController {
         return ApiResponse.onSuccess(likesService.postLike(postId, memberId));
 
     }
-    /*
-    // 게시글 좋아요 취소
-    @DeleteMapping("likes/{postId}")
-    @Operation(summary = "특정게시글 좋아요 취소 요청", description = "해당 게시글에 대해 좋아요를 취소합니다")
-    @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> LikeCancelPost(@PathVariable Long postId, HttpServletRequest request){
-
-        Long memberId = jwtProvider.getUserIdFromToken(request);
-        return ApiResponse.onSuccess(likesService.postLikeCancel(postId, memberId));
-
-    }
-    */
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
@@ -22,7 +22,7 @@ public class LikesController {
 
     // 게시글 좋아요 등록
     @PostMapping("likes/{postId}")
-    @Operation(summary = "특정게시글 좋아요 요청", description = "해당 게시글에 대해 좋아요를 누릅니다")
+    @Operation(summary = "특정게시글 좋아요 삭제/생성 요청", description = "해당 게시글에 대해 좋아요를 누르지 않았다면 좋아요 생성, 이미 눌렀다면 좋아요 삭제를 합니다")
     @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
     public ApiResponse<String> LikePost(@PathVariable Long postId, HttpServletRequest request){
 
@@ -31,7 +31,7 @@ public class LikesController {
         return ApiResponse.onSuccess(likesService.postLike(postId, memberId));
 
     }
-
+    /*
     // 게시글 좋아요 취소
     @DeleteMapping("likes/{postId}")
     @Operation(summary = "특정게시글 좋아요 취소 요청", description = "해당 게시글에 대해 좋아요를 취소합니다")
@@ -42,4 +42,6 @@ public class LikesController {
         return ApiResponse.onSuccess(likesService.postLikeCancel(postId, memberId));
 
     }
+    */
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
@@ -14,23 +14,38 @@ public class LikesService {
 
     // 좋아요 등록
     public String postLike(Long postId, Long memberId) {
-        try {
 
-            Likes likes = Likes.builder()
-                    .postId(postId)
-                    .memberId(memberId)
-                    .build();
+        Likes liked = likeRepository.findByPostIdAndMemberId(postId, memberId);
 
-            likeRepository.save(likes);
-            postService.getLiked(postId); // 포스트에 좋아요 추가
+        if (liked == null) {
+            try {
+                Likes likes = Likes.builder()
+                        .postId(postId)
+                        .memberId(memberId)
+                        .build();
 
-            return "게시물 좋아요가 성공적으로 등록되었습니다.";
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "게시물 좋아요 등록 중 오류가 발생했습니다: " + e.getMessage();
+                likeRepository.save(likes);
+                postService.getLiked(postId); // 포스트에 좋아요 추가
+
+                return "게시물 좋아요가 성공적으로 등록되었습니다.";
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "게시물 좋아요 등록 중 오류가 발생했습니다: " + e.getMessage();
+            }
+        } else {
+            try {
+                likeRepository.delete(liked);
+                return "게시물 좋아요가 취소되었습니다.";
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "게시물 좋아요 취소 중 오류가 발생했습니다: " + e.getMessage();
+            }
         }
+
+
     }
 
+    /*
     // 좋아요 취소
     public String postLikeCancel(Long postId, Long memberId) {
         Likes likepost = likeRepository.findByPostIdAndMemberId(postId, memberId);
@@ -44,4 +59,5 @@ public class LikesService {
         }
 
     }
+     */
 }

--- a/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
@@ -45,19 +45,17 @@ public class LikesService {
 
     }
 
-    /*
-    // 좋아요 취소
-    public String postLikeCancel(Long postId, Long memberId) {
-        Likes likepost = likeRepository.findByPostIdAndMemberId(postId, memberId);
+    public boolean isLike(Long memberId, Long postId) {
+        Likes liked = likeRepository.findByPostIdAndMemberId(postId, memberId);
 
-        try {
-            likeRepository.delete(likepost);
-            return "게시물 좋아요가 취소되었습니다.";
-        } catch (Exception e) {
-            e.printStackTrace();
-            return "게시물 좋아요 취소 중 오류가 발생했습니다: " + e.getMessage();
+        if (liked != null) {
+            return true;
         }
-
+        else{
+            return false;
+        }
     }
-     */
+
+
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -92,10 +92,10 @@ public class PostController {
     }
 
     // BLOG004: 게시글 수정 요청
-    @PatchMapping("{esId}")
+    @PatchMapping("{postId}")
     @Operation(summary = "특정게시글 수정 요청", description = "해당 게시글을 수정합니다")
-    @Parameter(name = "esId", description = "포스트의 elasticsearch id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> EditBlog(HttpServletRequest request, @PathVariable String esId,
+    @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
+    public ApiResponse<String> EditBlog(HttpServletRequest request, @PathVariable Long postId,
             @RequestBody PostUpdateDto updateDto)
             throws JsonProcessingException {
 
@@ -103,19 +103,19 @@ public class PostController {
         Long memberId = jwtProvider.getUserIdFromToken(request);
         postHashtagService.sendAllHashtags(memberId, request);
 
-        return ApiResponse.onSuccess(postService.UpdatePost(esId, updateDto));
+        return ApiResponse.onSuccess(postService.UpdatePost(postId, updateDto));
     }
 
     // BLOG005: 게시글 삭제 요청
-    @DeleteMapping("{esId}")
+    @DeleteMapping("{postId}")
     @Operation(summary = "특정게시글 삭제 요청", description = "해당 게시글을 삭제합니다")
-    @Parameter(name = "esId", description = "포스트의 elasticsearch id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> deletePost(HttpServletRequest request, @PathVariable String esId) {
+    @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
+    public ApiResponse<String> deletePost(HttpServletRequest request, @PathVariable Long postId) {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
         postHashtagService.sendAllHashtags(memberId, request);
 
-        return ApiResponse.onSuccess(postService.deletePost(esId));
+        return ApiResponse.onSuccess(postService.deletePost(postId));
     }
 
     // BlOG007: 특정 멤버가 사용한 HASHTAG 값 조회

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.justdo.plug.post.domain.post.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.justdo.plug.post.domain.category.service.CategoryService;
+import com.justdo.plug.post.domain.likes.service.LikesService;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.dto.*;
@@ -37,6 +38,7 @@ public class PostController {
     private final CategoryService categoryService;
     private final PhotoService photoService;
     private final JwtProvider jwtProvider;
+    private final LikesService likesService;
 
 
     // BLOG001: 게시글 리스트 조회 요청
@@ -52,9 +54,12 @@ public class PostController {
     @GetMapping("{postId}")
     @Operation(summary = "특정 게시글 상세페이지 조회 요청", description = "특정 게시글의 상세페이지를 요청합니다")
     @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<PostResponseDto> ViewPage(@PathVariable Long postId) throws JSONException {
+    public ApiResponse<PostResponseDto> ViewPage(HttpServletRequest request, @PathVariable Long postId) throws JSONException {
 
-        return ApiResponse.onSuccess(postService.getPostById(postId));
+        Long memberId = jwtProvider.getUserIdFromToken(request);
+        boolean isLike = likesService.isLike(memberId, postId);
+
+        return ApiResponse.onSuccess(postService.getPostById(postId, memberId, isLike));
 
     }
 

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -43,7 +43,7 @@ public class PostController {
 
     // BLOG001: 게시글 리스트 조회 요청
     @GetMapping
-    @Operation(summary = "모든 게시글 리스트 조회 요청", description = "서비스내에 있는 모든 게시글 리스트를 조회합니다")
+    @Operation(summary = "모든 게시글 리스트 조회 요청", description = "데이터 베이스 내에 있는 모든 게시글 리스트를 조회 합니다")
     public ApiResponse<List<Post>> ViewList() {
 
         return ApiResponse.onSuccess(postService.getAllPosts());
@@ -52,7 +52,7 @@ public class PostController {
 
     // BLOG002: 게시글 상세페이지 조회 요청
     @GetMapping("{postId}")
-    @Operation(summary = "특정 게시글 상세페이지 조회 요청", description = "특정 게시글의 상세페이지를 요청합니다")
+    @Operation(summary = "특정 게시글 상세 페이지 조회 요청", description = "특정 게시글의 상세 페이지를 요청합니다(제목, 글, 좋아요 갯수, 현재 사용자가 좋아요 했는지 여부 등)")
     @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
     public ApiResponse<PostResponseDto> ViewPage(HttpServletRequest request, @PathVariable Long postId) throws JSONException {
 

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -19,9 +19,10 @@ public class PostResponseDto {
     private LocalDateTime updatedAt;
     private Long memberId;
     private Long blogId;
+    private boolean isLike;
 
     // SUB: 게시글 반환 함수
-    public static PostResponseDto createFromPost(Post post) {
+    public static PostResponseDto createFromPost(Post post, boolean isLike) {
         String JsonContent = post.getContent();
         JSONArray jsonArray = new JSONArray(JsonContent);
         List<Object> list = jsonArray.toList();
@@ -38,6 +39,8 @@ public class PostResponseDto {
                 .updatedAt(post.getUpdatedAt())
                 .memberId(post.getMemberId())
                 .blogId(post.getBlogId())
+                .isLike(isLike)
                 .build();
     }
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponseDto.java
@@ -20,9 +20,10 @@ public class PostResponseDto {
     private Long memberId;
     private Long blogId;
     private boolean isLike;
+    private boolean isSubscribe;
 
     // SUB: 게시글 반환 함수
-    public static PostResponseDto createFromPost(Post post, boolean isLike) {
+    public static PostResponseDto createFromPost(Post post, boolean isLike, boolean isSubscribe) {
         String JsonContent = post.getContent();
         JSONArray jsonArray = new JSONArray(JsonContent);
         List<Object> list = jsonArray.toList();
@@ -40,7 +41,9 @@ public class PostResponseDto {
                 .memberId(post.getMemberId())
                 .blogId(post.getBlogId())
                 .isLike(isLike)
+                .isSubscribe(isSubscribe)
                 .build();
+
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -304,15 +304,15 @@ public class PostService {
     }
 
     @Transactional
-    public String deletePost(String esId) {
+    public String deletePost(Long postId) {
 
         // MySQL
         // EsId 값으로 Post를 찾기
 
-        Post post = postRepository.findByEsId(esId)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
 
-        Long postId = post.getId();
+        String esId = post.getEsId();
         postHashtagService.deletePostHashtags(postId);
 
         List<Photo> photos = photoRepository.findAllByPostId(postId);
@@ -388,15 +388,15 @@ public class PostService {
     }
 
     @Transactional
-    public String UpdatePost(String id, PostUpdateDto updateDto) throws JsonProcessingException {
+    public String UpdatePost(Long postId, PostUpdateDto updateDto) throws JsonProcessingException {
 
         String content = updateDto.getContent();
         String preview = parseContent(content);
 
 
-        Post post = postRepository.findByEsId(id)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
-        Long postId = post.getId();
+        String esId = post.getEsId();
 
         // 카테고리 변경
         Category category = categoryRepository.findByPostId(postId)
@@ -436,7 +436,7 @@ public class PostService {
         }
 
         // Elasticsearch
-        String updateURL = url + "/post/_update/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
+        String updateURL = url + "/post/_update/" + URLEncoder.encode(esId, StandardCharsets.UTF_8);
 
         HttpRequest updateRequest = HttpRequest.newBuilder()
             .uri(URI.create(updateURL))

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.justdo.plug.post.domain.blog.BlogClient;
+import com.justdo.plug.post.domain.blog.SubscriptionRequest;
 import com.justdo.plug.post.domain.category.Category;
 import com.justdo.plug.post.domain.category.repository.CategoryRepository;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
@@ -83,7 +84,15 @@ public class PostService {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
 
-        return PostResponseDto.createFromPost(post, isLike);
+        Long blogId = post.getBlogId();
+
+        SubscriptionRequest.LoginSubscription loginSubscription = new SubscriptionRequest.LoginSubscription();
+        loginSubscription.setMemberId(memberId);
+        loginSubscription.setBlogId(blogId);
+
+        boolean isSubscribe = blogClient.checkSubscribeById(loginSubscription);
+
+        return PostResponseDto.createFromPost(post, isLike, isSubscribe);
     }
 
     // BLOG003: 블로그 작성
@@ -253,7 +262,7 @@ public class PostService {
             System.out.println("totalValue = " + totalValue);
 
             // search 결과 리스트 반환
-            List<SearchResponse.PostSearch> searchResponseList = new ArrayList<>();
+            List<PostSearch> searchResponseList = new ArrayList<>();
             List<Long> postIdList = new ArrayList<>(); // Photo 조회
             List<Long> blogIdList = new ArrayList<>(); // Blog 조회
             JsonNode hitsNode = rootNode.path("hits").path("hits");

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import com.justdo.plug.post.domain.category.Category;
 import com.justdo.plug.post.domain.category.repository.CategoryRepository;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.likes.repository.LikesRepository;
+import com.justdo.plug.post.domain.likes.service.LikesService;
 import com.justdo.plug.post.domain.photo.Photo;
 import com.justdo.plug.post.domain.photo.repository.PhotoRepository;
 import com.justdo.plug.post.domain.photo.service.PhotoService;
@@ -59,7 +60,6 @@ public class PostService {
     private final PostElasticsearchRepository postElasticsearchRepository;
     private final PhotoService photoService;
     private final BlogClient blogClient;
-    private final PostHashtagRepository postHashtagRepository;
     private final PhotoRepository photoRepository;
     private final CategoryRepository categoryRepository;
     private final LikesRepository likesRepository;
@@ -79,11 +79,11 @@ public class PostService {
     }
 
     // BLOG002: 게시글 상세 페이지 조회
-    public PostResponseDto getPostById(Long postId) throws JSONException {
+    public PostResponseDto getPostById(Long postId, Long memberId, boolean isLike) throws JSONException {
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new ApiException(ErrorStatus._POST_NOT_FOUND));
 
-        return PostResponseDto.createFromPost(post);
+        return PostResponseDto.createFromPost(post, isLike);
     }
 
     // BLOG003: 블로그 작성


### PR DESCRIPTION
## 📌 요약

- 게시글 좋아요 로직 수정(likes 테이블 증복 처리)
- 좋아요 API 하나로 변경(좋아요 생성 or 눌렀다면 좋아요 삭제)
- 게시글 조회시 좋아요 및 블로그 구독 여부 반환

## 📝 상세 내용

-

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
