### PR TITLE
Glue 332 Fix: Likes 엔티티 수정 및 좋아요 요청/취소 API 트랜잭션 적용, 코드 리팩토링

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/likes/Likes.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/Likes.java
@@ -1,6 +1,7 @@
 package com.justdo.plug.post.domain.likes;
 
 import com.justdo.plug.post.domain.common.BaseTimeEntity;
+import com.justdo.plug.post.domain.post.Post;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,7 +19,8 @@ public class Likes extends BaseTimeEntity {
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/controller/LikesController.java
@@ -1,5 +1,6 @@
 package com.justdo.plug.post.domain.likes.controller;
 
+import com.justdo.plug.post.domain.likes.dto.LikesResponse;
 import com.justdo.plug.post.domain.likes.service.LikesService;
 import com.justdo.plug.post.global.response.ApiResponse;
 import com.justdo.plug.post.global.utils.JwtProvider;
@@ -24,7 +25,7 @@ public class LikesController {
     @PostMapping("likes/{postId}")
     @Operation(summary = "특정게시글 좋아요 삭제/생성 요청", description = "해당 게시글에 대해 좋아요를 누르지 않았다면 좋아요 생성, 이미 눌렀다면 좋아요 삭제를 합니다")
     @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
-    public ApiResponse<String> LikePost(@PathVariable Long postId, HttpServletRequest request){
+    public ApiResponse<LikesResponse> LikePost(@PathVariable Long postId, HttpServletRequest request){
 
 
         Long memberId = jwtProvider.getUserIdFromToken(request);

--- a/src/main/java/com/justdo/plug/post/domain/likes/dto/LikesResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/dto/LikesResponse.java
@@ -1,0 +1,26 @@
+package com.justdo.plug.post.domain.likes.dto;
+
+import com.justdo.plug.post.domain.likes.Likes;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class LikesResponse {
+
+    private Long likeId;
+    private LocalDateTime createdAt;
+
+    public static LikesResponse toLikeResponse(Likes likes) {
+
+        return LikesResponse.builder()
+                .likeId(likes.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/justdo/plug/post/domain/likes/dto/LikesResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/dto/LikesResponse.java
@@ -1,6 +1,7 @@
 package com.justdo.plug.post.domain.likes.dto;
 
 import com.justdo.plug.post.domain.likes.Likes;
+import com.justdo.plug.post.domain.post.Post;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +22,14 @@ public class LikesResponse {
         return LikesResponse.builder()
                 .likeId(likes.getId())
                 .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Likes toEntity(Post post, Long memberId) {
+
+        return Likes.builder()
+                .post(post)
+                .memberId(memberId)
                 .build();
     }
 }

--- a/src/main/java/com/justdo/plug/post/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/repository/LikesRepository.java
@@ -2,12 +2,14 @@ package com.justdo.plug.post.domain.likes.repository;
 
 import com.justdo.plug.post.domain.likes.Likes;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikesRepository extends JpaRepository<Likes, Long> {
-    Likes findByPostIdAndMemberId(Long postId, Long memberId);
+
+    Optional<Likes> findByPostIdAndMemberId(Long postId, Long memberId);
 
     @Transactional
     void deleteByPostId(Long postId);

--- a/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
@@ -39,10 +39,7 @@ public class LikesService {
 
     private LikesResponse createLike(Post post, Long memberId) {
 
-        Likes newLike = Likes.builder()
-                .post(post)
-                .memberId(memberId)
-                .build();
+        Likes newLike = LikesResponse.toEntity(post, memberId);
         likeRepository.save(newLike);
         post.increaseLike();
 

--- a/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
@@ -11,13 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class LikesService {
     private final LikesRepository likeRepository;
     private final PostService postService;
 
     // 좋아요 등록
-    @Transactional
     public LikesResponse postLike(Long postId, Long memberId) {
 
         return likeRepository.findByPostIdAndMemberId(postId, memberId)
@@ -25,6 +24,7 @@ public class LikesService {
                 .orElseGet(()-> createLike(postService.getPost(postId), memberId));
     }
 
+    @Transactional(readOnly = true)
     public boolean isLike(Long memberId, Long postId) {
 
         return likeRepository.findByPostIdAndMemberId(postId, memberId).isPresent();

--- a/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
+++ b/src/main/java/com/justdo/plug/post/domain/likes/service/LikesService.java
@@ -1,59 +1,52 @@
 package com.justdo.plug.post.domain.likes.service;
 
 import com.justdo.plug.post.domain.likes.Likes;
+import com.justdo.plug.post.domain.likes.dto.LikesResponse;
 import com.justdo.plug.post.domain.likes.repository.LikesRepository;
+import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LikesService {
     private final LikesRepository likeRepository;
     private final PostService postService;
 
     // 좋아요 등록
-    public String postLike(Long postId, Long memberId) {
+    @Transactional
+    public LikesResponse postLike(Long postId, Long memberId) {
 
-        Likes liked = likeRepository.findByPostIdAndMemberId(postId, memberId);
-
-        if (liked == null) {
-            try {
-                Likes likes = Likes.builder()
-                        .postId(postId)
-                        .memberId(memberId)
-                        .build();
-
-                likeRepository.save(likes);
-                postService.getLiked(postId); // 포스트에 좋아요 추가
-
-                return "게시물 좋아요가 성공적으로 등록되었습니다.";
-            } catch (Exception e) {
-                e.printStackTrace();
-                return "게시물 좋아요 등록 중 오류가 발생했습니다: " + e.getMessage();
-            }
-        } else {
-            try {
-                likeRepository.delete(liked);
-                return "게시물 좋아요가 취소되었습니다.";
-            } catch (Exception e) {
-                e.printStackTrace();
-                return "게시물 좋아요 취소 중 오류가 발생했습니다: " + e.getMessage();
-            }
-        }
-
-
+        return likeRepository.findByPostIdAndMemberId(postId, memberId)
+                .map(this::deleteLike)
+                .orElseGet(()-> createLike(postService.getPost(postId), memberId));
     }
 
     public boolean isLike(Long memberId, Long postId) {
-        Likes liked = likeRepository.findByPostIdAndMemberId(postId, memberId);
 
-        if (liked != null) {
-            return true;
-        }
-        else{
-            return false;
-        }
+        return likeRepository.findByPostIdAndMemberId(postId, memberId).isPresent();
+    }
+
+    private LikesResponse deleteLike(Likes likes) {
+        likeRepository.delete(likes);
+        likes.getPost().decreaseLike();
+
+        return LikesResponse.toLikeResponse(likes);
+    }
+
+    private LikesResponse createLike(Post post, Long memberId) {
+
+        Likes newLike = Likes.builder()
+                .post(post)
+                .memberId(memberId)
+                .build();
+        likeRepository.save(newLike);
+        post.increaseLike();
+
+        return LikesResponse.toLikeResponse(newLike);
     }
 
 

--- a/src/main/java/com/justdo/plug/post/domain/post/Post.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/Post.java
@@ -68,4 +68,12 @@ public class Post extends BaseTimeEntity {
     public void changePreview(String preview) {
         this.preview = preview;
     }
+
+    public void increaseLike() {
+        this.likeCount++;
+    }
+
+    public void decreaseLike() {
+        this.likeCount--;
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/repository/PostRepository.java
@@ -1,12 +1,9 @@
 package com.justdo.plug.post.domain.post.repository;
 
 import com.justdo.plug.post.domain.post.Post;
-import java.util.List;
-
-import java.util.Optional;
-
 import feign.Param;
-import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;


### PR DESCRIPTION
## 📌 요약

- Likes 엔티티 수정
- 좋아요 요청/취소 API 트랜잭션 적용
- 코드 리팩토링

## 📝 상세 내용

- 엔티티 연관관계 설정 필수!!!
<img width="1227" alt="image" src="https://github.com/DoTheZ-Team/post-service/assets/103489352/f143f583-abdd-43e7-a920-e56cfac37b08">


> LikeService, LikseRepository 적용한 것 꼭 확인바람

## 🗣️ 질문 및 이외 사항

- 좋아요 요청 시, likecount 증가하는 쿼리만 있고, 삭제하는 쿼리는 왜 없는지? (있으면 어떻게 했는지 알려주면 좋을듯)

## ☑️ 이슈 번호

- close #
