### PR TITLE
Glue 356/hotfix post delete logic & post dto

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/auth/AuthClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/auth/AuthClient.java
@@ -1,0 +1,14 @@
+package com.justdo.plug.post.domain.auth;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "auth-service", url = "${application.config.auths-url}")
+public interface AuthClient {
+
+    @GetMapping("blogs/{memberId}")
+    String getMemberName(@PathVariable Long memberId);
+
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/auth/MemberInfoResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/auth/MemberInfoResponse.java
@@ -1,0 +1,17 @@
+package com.justdo.plug.post.domain.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberInfoResponse {
+
+    @Schema(description = "유저 이메일", example = "ht0729@gachon.ac.kr")
+    private String email;
+    @Schema(description = "유저 닉네임", example = "정성실")
+    private String nickname;
+
+}

--- a/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/repository/CommentRepository.java
@@ -10,4 +10,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostIdAndParentCommentIsNull(Long postId, PageRequest pageRequest);
 
     Page<Comment> findAllByParentCommentId(Long parentId, PageRequest pageRequest);
+
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
+++ b/src/main/java/com/justdo/plug/post/domain/comment/service/CommentService.java
@@ -123,4 +123,8 @@ public class CommentService {
 
         return CommentResponse.toCommentItemList(commentPage, blogInfoList, parentId);
     }
+
+    public void deleteComments(Long postId) {
+        commentRepository.deleteByPostId(postId);
+    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -51,6 +51,7 @@ public class PostController {
     private final LikesService likesService;
 
 
+
     // BLOG001: 게시글 리스트 조회 요청
     @GetMapping("all")
     @Operation(summary = "모든 게시글 리스트 조회 요청", description = "데이터 베이스 내에 있는 모든 게시글 리스트를 조회 합니다")
@@ -95,7 +96,8 @@ public class PostController {
         photoService.createPhoto(requestDto.getPhotoUrls(), post);
 
         // 4. Recommend Service 로 해시태그 보내주기
-        postHashtagService.sendNewHashtags(memberId, requestDto.getHashtags(), request);
+        postHashtagService.sendNewHashtags(blogId, requestDto.getHashtags(), request);
+
 
         return ApiResponse.onSuccess("게시글이 성공적으로 업로드 되었습니다");
     }
@@ -107,10 +109,11 @@ public class PostController {
     public ApiResponse<String> EditBlog(HttpServletRequest request, @PathVariable Long postId,
             @RequestBody PostUpdateDto updateDto)
             throws JsonProcessingException {
-
+        Post post = postService.getPost(postId);
+        Long blogId = post.getBlogId();
         // 전체 해시태그 Recommend Service 로 보내주기
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        postHashtagService.sendAllHashtags(memberId, request);
+        postHashtagService.sendAllHashtags(memberId, blogId, request);
 
         return ApiResponse.onSuccess(postService.UpdatePost(postId, updateDto));
     }
@@ -121,8 +124,11 @@ public class PostController {
     @Parameter(name = "postId", description = "포스트의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
     public ApiResponse<String> deletePost(HttpServletRequest request, @PathVariable Long postId) {
 
+        Post post = postService.getPost(postId);
+        Long blogId = post.getBlogId();
+
         Long memberId = jwtProvider.getUserIdFromToken(request);
-        postHashtagService.sendAllHashtags(memberId, request);
+        postHashtagService.sendAllHashtags(memberId, blogId, request);
 
         return ApiResponse.onSuccess(postService.deletePost(postId));
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
@@ -40,6 +40,9 @@ public class PostResponse {
     @AllArgsConstructor
     public static class PostDetail {
 
+        @Schema(description = "사용자 nickname")
+        private String nickname;
+
         @Schema(description = "포스트 ID")
         private Long postId;
 
@@ -84,11 +87,12 @@ public class PostResponse {
 
         @Schema(description = "포스트의 스티커 정보")
         PostStickerDTO.PostStickerUrlItems postStickerUrlItems;
+
     }
 
     // SUB: 게시글 반환 함수
     public static PostResponse.PostDetail toPostDetail(Post post, boolean isLike,
-            boolean isSubscribe, List<String> postHashtags, String categoryName, List<String> photoUrls, PostStickerDTO.PostStickerUrlItems postStickerUrlItems) {
+            boolean isSubscribe, List<String> postHashtags, String categoryName, List<String> photoUrls, PostStickerDTO.PostStickerUrlItems postStickerUrlItems, String nickname) {
 
         String JsonContent = post.getContent();
         JSONArray jsonArray = new JSONArray(JsonContent);
@@ -96,6 +100,7 @@ public class PostResponse {
         Object[] array = list.toArray();
 
         return PostDetail.builder()
+                .nickname(nickname)
                 .postId(post.getId())
                 .title(post.getTitle())
                 .content(array)

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.justdo.plug.post.domain.post.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.justdo.plug.post.domain.auth.AuthClient;
 import com.justdo.plug.post.domain.blog.BlogClient;
 import com.justdo.plug.post.domain.blog.SubscriptionRequest;
 import com.justdo.plug.post.domain.comment.repository.CommentRepository;
@@ -29,7 +30,6 @@ import com.justdo.plug.post.domain.posthashtag.PostHashtag;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import com.justdo.plug.post.domain.sticker.PostStickerDTO;
 import com.justdo.plug.post.domain.sticker.StickerClient;
-import com.justdo.plug.post.domain.sticker.PostStickerDTO;
 import com.justdo.plug.post.elastic.PostDocument;
 import com.justdo.plug.post.elastic.PostElasticsearchRepository;
 import com.justdo.plug.post.global.exception.ApiException;
@@ -66,6 +66,7 @@ public class PostService {
     private final PostElasticsearchRepository postElasticsearchRepository;
     private final PhotoService photoService;
     private final BlogClient blogClient;
+    private final AuthClient authClient;
     private final StickerClient stickerClient;
     private final PhotoRepository photoRepository;
     private final LikesRepository likesRepository;
@@ -105,11 +106,14 @@ public class PostService {
         boolean isSubscribe = blogClient.checkSubscribeById(loginSubscription);
 
 
+        String nickname = authClient.getMemberName(memberId);
+
+
         PostStickerDTO.PostStickerUrlItems postStickerUrlItems = stickerClient.getStickers(postId);
         System.out.println("postStickerUrlItem = " + postStickerUrlItems);
 
 
-        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, categoryName, photoUrls, postStickerUrlItems);
+        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, categoryName, photoUrls, postStickerUrlItems, nickname);
     }
 
     // BLOG003: 블로그 작성
@@ -365,11 +369,8 @@ public class PostService {
             HttpResponse<String> deleteResponse = client.send(deleteRequest,
                     HttpResponse.BodyHandlers.ofString());
 
-            if (deleteResponse.statusCode() == 200) {
-                return "게시글이 삭제되었습니다.";
-            } else {
-                return "게시글 삭제도중 오류가 발생하였습니다: " + deleteResponse.statusCode();
-            }
+            return "게시글이 삭제되었습니다.";
+
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
             return e.toString();

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.justdo.plug.post.domain.blog.BlogClient;
 import com.justdo.plug.post.domain.blog.SubscriptionRequest;
+import com.justdo.plug.post.domain.comment.repository.CommentRepository;
 import com.justdo.plug.post.domain.hashtag.service.HashtagService;
 import com.justdo.plug.post.domain.likes.repository.LikesRepository;
 import com.justdo.plug.post.domain.photo.Photo;
@@ -68,6 +69,7 @@ public class PostService {
     private final StickerClient stickerClient;
     private final PhotoRepository photoRepository;
     private final LikesRepository likesRepository;
+    private final CommentRepository commentRepository;
 
 
     @Value("${spring.elasticsearch.uris}")
@@ -343,6 +345,9 @@ public class PostService {
 
         likesRepository.deleteByPostId(postId);
 
+        commentRepository.deleteByPostId(postId);
+
+        postElasticsearchRepository.deleteById(esId);
         // 찾은 Post 삭제
         postRepository.deleteByEsId(esId);
 

--- a/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
+++ b/src/main/java/com/justdo/plug/post/domain/posthashtag/service/PostHashtagService.java
@@ -33,10 +33,9 @@ public class PostHashtagService {
     private final PostRepository postRepository;
     private final JwtProvider jwtProvider;
 
-    @Value("${elasticsearch.api-key}")
-    private String apiKey;
 
     private final String recUrl = "http://210.109.54.22:8085";
+
 
     /**
      * Hashtag 생성
@@ -183,9 +182,9 @@ public class PostHashtagService {
         postHashtagRepository.deleteAll(postHashtags);
     }
 
-    public void sendNewHashtags(Long memberId, List<String> hashtags, HttpServletRequest request) {
+    public void sendNewHashtags(Long blogId, List<String> hashtags, HttpServletRequest request) {
 
-        String updateURL = recUrl + "/recommends/update";
+        String updateURL = recUrl + "/recommends/hashtags";
         String jsonBody;
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -193,8 +192,8 @@ public class PostHashtagService {
         try {
             Map<String, Object> docFields = new HashMap<>();
             docFields.put("newHashtag", hashtags);
-            docFields.put("memberId", memberId);
-
+            docFields.put("blogId", blogId);
+            System.out.println("docFields = " + docFields);
             jsonBody = objectMapper.writeValueAsString(docFields);
             HttpRequest updateRequest = HttpRequest.newBuilder()
                     .uri(URI.create(updateURL))
@@ -217,11 +216,11 @@ public class PostHashtagService {
         }
     }
 
-    public void sendAllHashtags(Long memberId, HttpServletRequest request){
+    public void sendAllHashtags(Long memberId, Long blogId, HttpServletRequest request){
 
         List<String> hashtags = getHashtags(memberId);
 
-        String updateURL = recUrl + "/recommends/edit";
+        String updateURL = recUrl + "/recommends/editings";
         String jsonBody;
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -229,8 +228,8 @@ public class PostHashtagService {
         try {
             Map<String, Object> docFields = new HashMap<>();
             docFields.put("changedHashtag", hashtags);
-            docFields.put("memberId", memberId);
-
+            docFields.put("blogId", blogId);
+            System.out.println("docFields = " + docFields);
             jsonBody = objectMapper.writeValueAsString(docFields);
             HttpRequest updateRequest = HttpRequest.newBuilder()
                     .uri(URI.create(updateURL))


### PR DESCRIPTION
## 📌 요약

- Post Response DTO에 멤버 닉네임 추가
- Post Delete 발생시 생기는 오류 수정(댓글 외래키 참조 오류)

## 📝 상세 내용

- PostResponseDTO 수정 되었습니다
- Post 상세 페이지 반환값 예시
<img width="570" alt="Screenshot 2024-05-29 at 6 00 13 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/1000a276-c986-4938-aeb0-f59bd08f606e">

- Post 삭제 
<img width="377" alt="Screenshot 2024-05-29 at 5 52 22 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/af1dc209-0831-45d1-b03f-e023d5df250c">


## 🗣️ 질문 및 이외 사항

- 아마 게시글 삭제에서 timeout 뜬게 오류때문에 인거 같아서 이대로 다시 올리면 타임아웃은 뜨지 않을 것 같습니다

## ☑️ 이슈 번호

- close #
