### PR TITLE
Glue 370/hotfix sticker dto openfeign

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -15,6 +15,7 @@ import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemSlice;
 import com.justdo.plug.post.domain.post.dto.SearchResponse;
 import com.justdo.plug.post.domain.post.service.PostService;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
+import com.justdo.plug.post.domain.sticker.PostStickerDTO;
 import com.justdo.plug.post.global.response.ApiResponse;
 import com.justdo.plug.post.global.utils.JwtProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -89,6 +90,7 @@ public class PostController {
 
         // 1. Post 저장
         Post post = postService.save(requestDto, blogId, memberId);
+        Long postId = post.getId();
 
         // 2. Post_Hashtag 저장
         postHashtagService.createHashtag(requestDto.getHashtags(), post);
@@ -98,6 +100,16 @@ public class PostController {
 
         // 4. Recommend Service 로 해시태그 보내주기
         postHashtagService.sendNewHashtags(blogId, requestDto.getHashtags(), token);
+
+        // 5. Sticker Service 로 Sticker 정보 보내주기
+        List<PostStickerDTO.PostStickerItem> postStickerItemList = requestDto.getPostStickerItemList();
+        if (postStickerItemList != null) {
+            for (PostStickerDTO.PostStickerItem item : postStickerItemList) {
+                item.setPostId(postId);
+            }
+        }
+
+        postService.sendSticker(postStickerItemList);
 
         return ApiResponse.onSuccess("게시글이 성공적으로 업로드 되었습니다");
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -105,6 +105,7 @@ public class PostController {
         List<PostStickerDTO.PostStickerItem> postStickerItemList = requestDto.getPostStickerItemList();
         if (postStickerItemList != null) {
             for (PostStickerDTO.PostStickerItem item : postStickerItemList) {
+
                 item.setPostId(postId);
             }
         }

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostRequestDto.java
@@ -2,6 +2,8 @@ package com.justdo.plug.post.domain.post.dto;
 
 import com.justdo.plug.post.domain.post.Post;
 import java.util.List;
+
+import com.justdo.plug.post.domain.sticker.PostStickerDTO;
 import lombok.Getter;
 
 @Getter
@@ -13,6 +15,7 @@ public class PostRequestDto {
     private List<String> hashtags;
     private String categoryName;
     private List<String> photoUrls;
+    private List<PostStickerDTO.PostStickerItem> postStickerItemList;
 
     public Post toEntity(PostRequestDto postRequestDto, String preview, Long blogId,
             Long memberId) {

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
@@ -86,13 +86,13 @@ public class PostResponse {
         private List<String> photoUrls;
 
         @Schema(description = "포스트의 스티커 정보")
-        PostStickerDTO.PostStickerUrlItems postStickerUrlItems;
+        private List<PostStickerDTO.PostStickerItem> postStickerItems;
 
     }
 
     // SUB: 게시글 반환 함수
     public static PostResponse.PostDetail toPostDetail(Post post, boolean isLike,
-            boolean isSubscribe, List<String> postHashtags, String categoryName, List<String> photoUrls, PostStickerDTO.PostStickerUrlItems postStickerUrlItems, String nickname) {
+            boolean isSubscribe, List<String> postHashtags, String categoryName, List<String> photoUrls, List<PostStickerDTO.PostStickerItem> postStickerItems, String nickname) {
 
         String JsonContent = post.getContent();
         JSONArray jsonArray = new JSONArray(JsonContent);
@@ -115,7 +115,7 @@ public class PostResponse {
                 .postHashtags(postHashtags)
                 .categoryName(categoryName)
                 .photoUrls(photoUrls)
-                .postStickerUrlItems(postStickerUrlItems)
+                .postStickerItems(postStickerItems)
                 .build();
 
     }

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -109,10 +109,10 @@ public class PostService {
         String nickname = authClient.getMemberName(memberId);
 
 
-        PostStickerDTO.PostStickerUrlItems postStickerUrlItems = stickerClient.getStickersByPostId(postId);
+        List<PostStickerDTO.PostStickerItem> postStickerItems = stickerClient.getStickersByPostId(postId);
 
 
-        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, categoryName, photoUrls, postStickerUrlItems, nickname);
+        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, categoryName, photoUrls, postStickerItems, nickname);
     }
 
     // BLOG003: 블로그 작성

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -109,8 +109,7 @@ public class PostService {
         String nickname = authClient.getMemberName(memberId);
 
 
-        PostStickerDTO.PostStickerUrlItems postStickerUrlItems = stickerClient.getStickers(postId);
-        System.out.println("postStickerUrlItem = " + postStickerUrlItems);
+        PostStickerDTO.PostStickerUrlItems postStickerUrlItems = stickerClient.getStickersByPostId(postId);
 
 
         return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, categoryName, photoUrls, postStickerUrlItems, nickname);

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -490,4 +490,8 @@ public class PostService {
         );
     }
 
+    public void sendSticker(List<PostStickerDTO.PostStickerItem> postStickerItemList) {
+        stickerClient.savePostStickers(postStickerItemList);
+    }
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -48,7 +48,6 @@ public class PostStickerDTO {
     @Schema(description = "포스트에 저장된 스티커 리스트 정보 DTO")
     @Getter
     public static class PostStickerItems {
-        private Long postId;
         private List<PostStickerItem> postStickerItem;
     }
 
@@ -69,9 +68,8 @@ public class PostStickerDTO {
     public static class PostStickerUrlItems {
 
         @Schema(description = "url포함 포스트-스티커 리스트")
-        @JsonProperty("postStickerId")
+        @JsonProperty("postStickerUrlItems")
         private List<PostStickerUrlItem> postStickerUrlItems;
+
     }
-
-
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -9,44 +9,42 @@ import java.util.List;
 public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
-    public static class PostStickerItem {
 
-        @Schema(description = "포스트-스티커의 id")
-        @JsonProperty("postStickerId")
+    public static class PostStickerItem {
+        @Schema(description = "포스트-스티커의 id", example = "1")
         private Long postStickerId;
 
-        @Schema(description = "포스트의 id")
-        @JsonProperty("postId")
+        @Schema(description = "포스트의 id", example = "2")
         private Long postId;
 
-        @Schema(description = "스티커의 id")
-        @JsonProperty("stickerId")
+        @Schema(description = "스티커의 id", example = "3")
         private Long stickerId;
 
-        @Schema(description = "스티커의 x_location")
+        @Schema(description = "스티커의 url", example = "https://glue-bucket-sticker.s3.ap-northeast-2.amazonaws.com/54728a63-ff4b-4b3e-aea8-18036491b97c.png")
+        private String url;
+
+        @Schema(description = "스티커의 x 위치", example = "100")
         @JsonProperty("xLocation")
         private int xLocation;
 
-        @Schema(description = "스티커의 y_location")
+        @Schema(description = "스티커의 y 위치", example = "100")
         @JsonProperty("yLocation")
         private int yLocation;
 
-        @Schema(description = "스티커의 width")
-        @JsonProperty("width")
+        @Schema(description = "스티커의 scaleX", example = "100")
         private double scaleX;
 
-        @Schema(description = "스티커의 height")
-        @JsonProperty("height")
+        @Schema(description = "스티커의 scaleY", example = "100")
         private double scaleY;
 
-        @Schema(description = "스티커의 angle")
-        @JsonProperty("angle")
+        @Schema(description = "스티커의 rotation", example = "100")
         private double rotation;
 
         public void setPostId(Long postId) {
             this.postId = postId;
         }
     }
+
 
 
 

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
-
     public static class PostStickerItem {
         @Schema(description = "포스트-스티커의 id", example = "1")
         private Long postStickerId;
@@ -24,12 +24,12 @@ public class PostStickerDTO {
         private String url;
 
         @Schema(description = "스티커의 x 위치", example = "100")
-        @JsonProperty("xLocation")
-        private int xLocation;
+        @JsonProperty(value = "xLocation")
+        private int xlocation;
 
         @Schema(description = "스티커의 y 위치", example = "100")
-        @JsonProperty("yLocation")
-        private int yLocation;
+        @JsonProperty(value = "yLocation")
+        private int ylocation;
 
         @Schema(description = "스티커의 scaleX", example = "100")
         private double scaleX;
@@ -46,33 +46,4 @@ public class PostStickerDTO {
     }
 
 
-
-
-    @Schema(description = "포스트에 저장된 스티커 리스트 정보 DTO")
-    @Getter
-    public static class PostStickerItems {
-        private List<PostStickerItem> postStickerItem;
-    }
-
-    @Schema(description = "url포함 스티커 포스트 정보 DTO")
-    @Getter
-    public static class PostStickerUrlItem {
-
-        @Schema(description = "스티커 item")
-        private PostStickerItem postStickerItem;
-
-        @Schema(description = "스티커의 url")
-        private String url;
-
-    }
-
-    @Schema(description = "url 포함 스티커 포스트 정보 DTO")
-    @Getter
-    public static class PostStickerUrlItems {
-
-        @Schema(description = "url포함 포스트-스티커 리스트")
-        @JsonProperty("postStickerUrlItems")
-        private List<PostStickerUrlItem> postStickerUrlItems;
-
-    }
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -9,7 +9,6 @@ import java.util.List;
 public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
-    @Setter
     public static class PostStickerItem {
 
         @Schema(description = "포스트-스티커의 id")
@@ -43,7 +42,13 @@ public class PostStickerDTO {
         @Schema(description = "스티커의 angle")
         @JsonProperty("angle")
         private double rotation;
+
+        public void setPostId(Long postId) {
+            this.postId = postId;
+        }
     }
+
+
 
     @Schema(description = "포스트에 저장된 스티커 리스트 정보 DTO")
     @Getter

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
+    @Setter
     public static class PostStickerItem {
 
         @Schema(description = "포스트-스티커의 id")
@@ -33,22 +34,22 @@ public class PostStickerDTO {
 
         @Schema(description = "스티커의 width")
         @JsonProperty("width")
-        private int width;
+        private double scaleX;
 
         @Schema(description = "스티커의 height")
         @JsonProperty("height")
-        private int height;
+        private double scaleY;
 
         @Schema(description = "스티커의 angle")
         @JsonProperty("angle")
-        private int angle;
+        private double rotation;
     }
 
     @Schema(description = "포스트에 저장된 스티커 리스트 정보 DTO")
     @Getter
     public static class PostStickerItems {
         private Long postId;
-        private List<PostStickerItem> postStickerItems;
+        private List<PostStickerItem> postStickerItem;
     }
 
     @Schema(description = "url포함 스티커 포스트 정보 DTO")
@@ -71,4 +72,6 @@ public class PostStickerDTO {
         @JsonProperty("postStickerId")
         private List<PostStickerUrlItem> postStickerUrlItems;
     }
+
+
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface StickerClient {
 
     @GetMapping("/poststickers")
-    PostStickerDTO.PostStickerUrlItems getStickers(@RequestParam("postId") Long postId);
+    PostStickerDTO.PostStickerUrlItems getStickersByPostId(@RequestParam("postId") Long postId);
     @PostMapping("/post-list")
     void savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerItemList);
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
@@ -2,12 +2,17 @@ package com.justdo.plug.post.domain.sticker;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @FeignClient(name = "sticker-service", url ="${application.config.sticker-url}")
 public interface StickerClient {
 
     @GetMapping("/poststickers")
     PostStickerDTO.PostStickerUrlItems getStickers(@RequestParam("postId") Long postId);
-
+    @PostMapping("/post-list")
+    void savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerItemList);
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface StickerClient {
 
     @GetMapping("/poststickers")
-    PostStickerDTO.PostStickerUrlItems getStickersByPostId(@RequestParam("postId") Long postId);
+    List<PostStickerDTO.PostStickerItem> getStickersByPostId(@RequestParam("postId") Long postId);
     @PostMapping("/post-list")
     void savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerItemList);
 }


### PR DESCRIPTION
## 📌 요약

-  게시글 작성시 Sticker 정보 함께 전달하기
-  게시글 조회시 Sticker 정보 받아오기(수정)

## 📝 상세 내용

- 게시글 작성 요청(Sticker 정보 추가)
<img width="857" alt="Screenshot 2024-06-05 at 9 46 43 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/f0becdae-c3dd-4ae6-966e-d6b37dfa8cba">

- 게시글 조회 요청(Sticker 정보 List)
<img width="613" alt="Screenshot 2024-06-06 at 1 43 27 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/16e24cf4-3c34-4415-91ef-2990c3111ac1">

- 로직
Post 게시글 작성 -> 작성된 Post PostID값 받아오기 -> 받아온 postId값으로 스티커 생성

## 🗣️ 질문 및 이외 사항

- PostRequestDTO 수정 되었습니다. 참고바랍니다. @Collection50 

## ☑️ 이슈 번호

- close #
