### PR TITLE
GLUE-370/ Sticker DTO 불필요한 속성 제거

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerDTO.java
@@ -1,19 +1,19 @@
 package com.justdo.plug.post.domain.sticker;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
     public static class PostStickerItem {
+        @JsonIgnore
         @Schema(description = "포스트-스티커의 id", example = "1")
         private Long postStickerId;
 
+        @JsonIgnore
         @Schema(description = "포스트의 id", example = "2")
         private Long postId;
 


### PR DESCRIPTION
## 📌 요약

- 프론트로 넘겨주는 Sticker DTO 속성 제거(postId, postStickerId)


## 📝 상세 내용

- before
<img width="613" alt="Screenshot 2024-06-06 at 1 43 27 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/dc40e208-7bfc-4c97-9b41-858c3150a0b4">

- after
![Screenshot 2024-06-06 at 7 22 18 PM](https://github.com/DoTheZ-Team/post-service/assets/24919880/e65a0781-aabc-41ef-8ea5-0a63575b8873)


## 🗣️ 질문 및 이외 사항

- ResponseSticker DTO를 추가하려다가 경령화를 위해 @jsonIgnore로 제거했습니다. 

## ☑️ 이슈 번호

- close #
