### PR TITLE
GLUE-374/ Sticker DTO 수정 및 post memberId로 작성하기

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/blog/BlogClient.java
@@ -4,9 +4,7 @@ import com.justdo.plug.post.domain.blog.BlogDto.BlogInfo;
 import com.justdo.plug.post.domain.post.dto.SearchResponse.BlogInfoItem;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(name = "blog-service", url = "${application.config.blogs-url}")
 public interface BlogClient {
@@ -20,4 +18,7 @@ public interface BlogClient {
 
     @PostMapping("/subscriptions")
     boolean checkSubscribeById(@RequestBody SubscriptionRequest.LoginSubscription loginSubscription);
+
+    @GetMapping("members/{memberId}")
+    Long getBlogId(@PathVariable Long memberId);
 }

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -63,14 +63,16 @@ public class PostController {
         return ApiResponse.onSuccess(PostResponse.toPostDetailResult(memberId, postDetail));
     }
 
-    @PostMapping("{blogId}")
+    @PostMapping()
     @Operation(summary = "게시글 작성 요청", description = "해당(본인) 블로그에 게시글을 작성합니다")
     @Parameter(name = "blogId", description = "사용자 블로그의 id, Path Variable 입니다", required = true, in = ParameterIn.PATH)
     public ApiResponse<String> PostBlog(HttpServletRequest request,
-            @RequestBody PostRequestDto requestDto, @PathVariable Long blogId)
+            @RequestBody PostRequestDto requestDto)
             throws JsonProcessingException {
 
+
         Long memberId = jwtProvider.getUserIdFromToken(request);
+        Long blogId = postService.getBlogIdByMemberId(memberId);
         String token = jwtProvider.parseToken(request);
 
         Post post = postService.save(requestDto, blogId, memberId);

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PostResponse.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.justdo.plug.post.domain.post.Post;
 import com.justdo.plug.post.domain.sticker.PostStickerDTO;
+import com.justdo.plug.post.domain.sticker.PostStickerResponseDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -86,13 +87,13 @@ public class PostResponse {
         private List<String> photoUrls;
 
         @Schema(description = "포스트의 스티커 정보")
-        private List<PostStickerDTO.PostStickerItem> postStickerItems;
+        private List<PostStickerResponseDTO.PostStickerItem> postStickerItems;
 
     }
 
     // SUB: 게시글 반환 함수
     public static PostResponse.PostDetail toPostDetail(Post post, boolean isLike,
-            boolean isSubscribe, List<String> postHashtags, List<String> photoUrls, List<PostStickerDTO.PostStickerItem> postStickerItems, String nickname) {
+            boolean isSubscribe, List<String> postHashtags, List<String> photoUrls, List<PostStickerResponseDTO.PostStickerItem> postStickerItems, String nickname) {
 
         List<Object> contentList = new Gson().fromJson(post.getContent(),
                 new TypeToken<List<Object>>() {

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -27,6 +27,7 @@ import com.justdo.plug.post.domain.post.dto.SearchResponse.SearchInfo;
 import com.justdo.plug.post.domain.post.repository.PostRepository;
 import com.justdo.plug.post.domain.posthashtag.service.PostHashtagService;
 import com.justdo.plug.post.domain.sticker.PostStickerDTO;
+import com.justdo.plug.post.domain.sticker.PostStickerResponseDTO;
 import com.justdo.plug.post.domain.sticker.StickerClient;
 import com.justdo.plug.post.elastic.PostDocument;
 import com.justdo.plug.post.global.exception.ApiException;
@@ -90,7 +91,7 @@ public class PostService {
         boolean isSubscribe = blogClient.checkSubscribeById(loginSubscription);
         String nickname = authClient.getMemberName(memberId);
 
-        List<PostStickerDTO.PostStickerItem> postStickerItems = stickerClient.getStickersByPostId(postId);
+        List<PostStickerResponseDTO.PostStickerItem> postStickerItems = stickerClient.getStickersByPostId(postId);
 
         return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, photoUrls, postStickerItems, nickname);
 
@@ -389,6 +390,10 @@ public class PostService {
 
     public void sendSticker(List<PostStickerDTO.PostStickerItem> postStickerItemList) {
         stickerClient.savePostStickers(postStickerItemList);
+    }
+
+    public Long getBlogIdByMemberId(Long memberId) {
+        return blogClient.getBlogId(memberId);
     }
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerResponseDTO.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/PostStickerResponseDTO.java
@@ -3,15 +3,18 @@ package com.justdo.plug.post.domain.sticker;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.Getter;
 
-public class PostStickerDTO {
+public class PostStickerResponseDTO {
+
     @Schema(description = "스티커 포스트 정보 DTO")
     @Getter
     public static class PostStickerItem {
+        @JsonIgnore
         @Schema(description = "포스트-스티커의 id", example = "1")
         private Long postStickerId;
 
+        @JsonIgnore
         @Schema(description = "포스트의 id", example = "2")
         private Long postId;
 
@@ -42,6 +45,5 @@ public class PostStickerDTO {
             this.postId = postId;
         }
     }
-
 
 }

--- a/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
+++ b/src/main/java/com/justdo/plug/post/domain/sticker/StickerClient.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface StickerClient {
 
     @GetMapping("/poststickers")
-    List<PostStickerDTO.PostStickerItem> getStickersByPostId(@RequestParam("postId") Long postId);
+    List<PostStickerResponseDTO.PostStickerItem> getStickersByPostId(@RequestParam("postId") Long postId);
     @PostMapping("/post-list")
     void savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerItemList);
 }


### PR DESCRIPTION
## 📌 요약

- post 작성시 토큰만 보내면 게시글 작성할 수 있도록 수정했습니다(blog Openfeign으로 연결)
- Sticker Response DTO 추가로 스티커 작성 및 조회에 차별점을 확실히 두었습니다 (오류 방지) 

## 📝 상세 내용

- api endpoint 변경
<img width="947" alt="Screenshot 2024-06-06 at 10 51 30 PM" src="https://github.com/DoTheZ-Team/post-service/assets/24919880/ece8ac05-b0c6-4de8-bb68-17bdd3aebf90">

## 🗣️ 질문 및 이외 사항

- 

## ☑️ 이슈 번호

- close #
