### PR TITLE
Fix: 블로그 페이지 앨범 5개 전달하도록 수정

### DIFF
--- a/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/repository/PhotoRepository.java
@@ -11,6 +11,8 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     Optional<Photo> findFirstByPostId(Long postId);
 
+    List<Photo> findTop5ByPostId(Long postId);
+
     List<Photo> findAllByPostId(Long postId);
 
     void deleteByPostId(Long postId);

--- a/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/justdo/plug/post/domain/photo/service/PhotoService.java
@@ -42,6 +42,23 @@ public class PhotoService {
                 .toList();
     }
 
+    public List<String> findTop5PhotoByPostId(Long postId) {
+
+        List<String> photoList = photoRepository.findTop5ByPostId(postId)
+                .stream()
+                .map(Photo::getPhotoUrl)
+                .toList();
+
+        return photoList.isEmpty() ? null : photoList;
+    }
+
+    public List<List<String>> findTop5PhotoUrlsByPosts(List<Post> posts) {
+
+        return posts.stream()
+                .map(post -> findTop5PhotoByPostId(post.getId()))
+                .toList();
+    }
+
     public List<String> findPhotoUrlsByPostId(Long postId) {
 
         List<Photo> photos = photoRepository.findAllByPostId(postId);

--- a/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/controller/PostController.java
@@ -11,7 +11,7 @@ import com.justdo.plug.post.domain.post.dto.PostResponse.PostProc;
 import com.justdo.plug.post.domain.post.dto.PostUpdateDto;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.BlogPostItem;
-import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItem;
+import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemBy5Photo;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemSlice;
 import com.justdo.plug.post.domain.post.dto.SearchResponse;
 import com.justdo.plug.post.domain.post.service.PostService;
@@ -70,7 +70,6 @@ public class PostController {
     public ApiResponse<PostProc> PostBlog(HttpServletRequest request,
             @RequestBody PostRequestDto requestDto)
             throws JsonProcessingException {
-
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
         Long blogId = postService.getBlogIdByMemberId(memberId);
@@ -160,7 +159,7 @@ public class PostController {
 
         List<Post> recent4Post = postService.getRecent4Post(blogId);
 
-        List<PostItem> postItemList = postService.getPostItemList(recent4Post);
+        List<PostItemBy5Photo> postItemList = postService.getPostItemList(recent4Post);
         List<String> hashtagNames = postHashtagService.getHashtagNamesByPost(recent4Post);
 
         return PreviewResponse.toBlogPostItem(postItemList, hashtagNames);

--- a/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/dto/PreviewResponse.java
@@ -59,6 +59,47 @@ public class PreviewResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
+    public static class PostItemBy5Photo {
+
+        @Schema(description = "Blog 아이디")
+        private Long blogId;
+
+        @Schema(description = "Post 아이디")
+        private Long postId;
+
+        @Schema(description = "Post 제목")
+        private String title;
+
+        @Schema(description = "Post 글 미리보기")
+        private String preview;
+
+        @Schema(description = "Post의 추가된 사진 경로")
+        private List<String> photoUrl;
+    }
+
+    public static PostItemBy5Photo toPostItemBy5Photo(Post post, List<String> photoUrl) {
+        return PostItemBy5Photo.builder()
+                .blogId(post.getBlogId())
+                .postId(post.getId())
+                .title(post.getTitle())
+                .preview(post.getPreview())
+                .photoUrl(photoUrl)
+                .build();
+    }
+
+    public static List<PostItemBy5Photo> toPostItemBy5Photo(List<Post> posts, List<List<String>> photoUrls) {
+
+        return IntStream.range(0, posts.size())
+                .mapToObj(idx -> {
+                    return toPostItemBy5Photo(posts.get(idx), photoUrls.get(idx));
+                })
+                .toList();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
     public static class PostItemSlice {
 
         private List<PostItem> postItems;
@@ -144,13 +185,13 @@ public class PreviewResponse {
     @Builder
     public static class BlogPostItem {
 
-        private List<PostItem> postItems;
+        private List<PostItemBy5Photo> postItems;
 
         @Schema(description = "Post에 작성된 해시태그 목록")
         private List<String> hashtagNames;
     }
 
-    public static BlogPostItem toBlogPostItem(List<PostItem> postItems, List<String> hashtagNames) {
+    public static BlogPostItem toBlogPostItem(List<PostItemBy5Photo> postItems, List<String> hashtagNames) {
 
         return BlogPostItem.builder()
                 .postItems(postItems)

--- a/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
+++ b/src/main/java/com/justdo/plug/post/domain/post/service/PostService.java
@@ -16,7 +16,7 @@ import com.justdo.plug.post.domain.post.dto.PostRequestDto;
 import com.justdo.plug.post.domain.post.dto.PostResponse;
 import com.justdo.plug.post.domain.post.dto.PostUpdateDto;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse;
-import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItem;
+import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemBy5Photo;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.PostItemSlice;
 import com.justdo.plug.post.domain.post.dto.PreviewResponse.StoryItem;
 import com.justdo.plug.post.domain.post.dto.SearchResponse;
@@ -91,9 +91,11 @@ public class PostService {
         boolean isSubscribe = blogClient.checkSubscribeById(loginSubscription);
         String nickname = authClient.getMemberName(memberId);
 
-        List<PostStickerResponseDTO.PostStickerItem> postStickerItems = stickerClient.getStickersByPostId(postId);
+        List<PostStickerResponseDTO.PostStickerItem> postStickerItems = stickerClient.getStickersByPostId(
+                postId);
 
-        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, photoUrls, postStickerItems, nickname);
+        return PostResponse.toPostDetail(post, isLike, isSubscribe, postHashtags, photoUrls,
+                postStickerItems, nickname);
 
     }
 
@@ -294,11 +296,11 @@ public class PostService {
     }
 
     // 최신 postItem 4개 조회
-    public List<PostItem> getPostItemList(List<Post> posts) {
+    public List<PostItemBy5Photo> getPostItemList(List<Post> posts) {
 
-        List<String> photoUrls = photoService.findPhotoUrlsByPosts(posts);
+        List<List<String>> photoUrls = photoService.findTop5PhotoUrlsByPosts(posts);
 
-        return PreviewResponse.toPostItemList(posts, photoUrls);
+        return PreviewResponse.toPostItemBy5Photo(posts, photoUrls);
     }
 
     // 최신 post 4개 조회


### PR DESCRIPTION
## 📌 요약

- 블로그 페이지 앨범 5개 전달하도록 수정

## 📝 상세 내용

- List<Photo> findTop5ByPostId(Long postId); : JPA 쿼리 메소드를 통해 상위 5개의 Photo 조회
- PostItemBy5Photo DTO 추가하여 기존의 DTO 변경하게 하지 않았습니다.

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
